### PR TITLE
Use Spring Cloud Stream Parent directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,22 +6,12 @@
 	<packaging>pom</packaging>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
-		<artifactId>spring-cloud-build</artifactId>
-		<version>1.1.1.RELEASE</version>
+		<artifactId>spring-cloud-stream-parent</artifactId>
+		<version>1.1.0.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
-	<properties>
-		<spring-boot.version>1.4.0.BUILD-SNAPSHOT</spring-boot.version>
-	</properties>
 	<dependencyManagement>
 		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-dependencies</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-binder-rabbit</artifactId>


### PR DESCRIPTION
Since the intent for `spring-cloud-stream-dependencies` to
become the user-facing dependency management BOM, binder
implementations should switch to the Spring Cloud Stream
parent for version management.

This also ensures that they inherit the build lifecycle of
Spring Cloud Stream - e.g. checkstyle validation.