### PR TITLE
Add new binding consumer property for anonymous queue

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitConsumerProperties.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitConsumerProperties.java
@@ -36,7 +36,8 @@ public class RabbitConsumerProperties {
 
 	private int prefetch = 1;
 
-	private String[] requestHeaderPatterns = new String[] {"STANDARD_REQUEST_HEADERS", "*"};
+	private String[] requestHeaderPatterns = new String[] { "STANDARD_REQUEST_HEADERS",
+			"*" };
 
 	private int txSize = 1;
 
@@ -48,15 +49,17 @@ public class RabbitConsumerProperties {
 
 	private boolean requeueRejected = false;
 
-	private String[] replyHeaderPatterns = new String[] {"STANDARD_REPLY_HEADERS", "*"};
+	private String[] replyHeaderPatterns = new String[] { "STANDARD_REPLY_HEADERS", "*" };
 
 	private long recoveryInterval = 5000;
+
+	private boolean useHashBindingKey = true;
 
 	public String getPrefix() {
 		return prefix;
 	}
 
-	public void setPrefix(String prefix) {
+	public void setPrefix(final String prefix) {
 		this.prefix = prefix;
 	}
 
@@ -64,7 +67,7 @@ public class RabbitConsumerProperties {
 		return transacted;
 	}
 
-	public void setTransacted(boolean transacted) {
+	public void setTransacted(final boolean transacted) {
 		this.transacted = transacted;
 	}
 
@@ -72,7 +75,7 @@ public class RabbitConsumerProperties {
 		return acknowledgeMode;
 	}
 
-	public void setAcknowledgeMode(AcknowledgeMode acknowledgeMode) {
+	public void setAcknowledgeMode(final AcknowledgeMode acknowledgeMode) {
 		Assert.notNull("Acknowledge mode cannot be null");
 		this.acknowledgeMode = acknowledgeMode;
 	}
@@ -82,7 +85,7 @@ public class RabbitConsumerProperties {
 		return maxConcurrency;
 	}
 
-	public void setMaxConcurrency(int maxConcurrency) {
+	public void setMaxConcurrency(final int maxConcurrency) {
 		this.maxConcurrency = maxConcurrency;
 	}
 
@@ -91,7 +94,7 @@ public class RabbitConsumerProperties {
 		return prefetch;
 	}
 
-	public void setPrefetch(int prefetch) {
+	public void setPrefetch(final int prefetch) {
 		this.prefetch = prefetch;
 	}
 
@@ -99,7 +102,7 @@ public class RabbitConsumerProperties {
 		return requestHeaderPatterns;
 	}
 
-	public void setRequestHeaderPatterns(String[] requestHeaderPatterns) {
+	public void setRequestHeaderPatterns(final String[] requestHeaderPatterns) {
 		this.requestHeaderPatterns = requestHeaderPatterns;
 	}
 
@@ -108,7 +111,7 @@ public class RabbitConsumerProperties {
 		return txSize;
 	}
 
-	public void setTxSize(int txSize) {
+	public void setTxSize(final int txSize) {
 		this.txSize = txSize;
 	}
 
@@ -116,7 +119,7 @@ public class RabbitConsumerProperties {
 		return autoBindDlq;
 	}
 
-	public void setAutoBindDlq(boolean autoBindDlq) {
+	public void setAutoBindDlq(final boolean autoBindDlq) {
 		this.autoBindDlq = autoBindDlq;
 	}
 
@@ -124,7 +127,7 @@ public class RabbitConsumerProperties {
 		return durableSubscription;
 	}
 
-	public void setDurableSubscription(boolean durableSubscription) {
+	public void setDurableSubscription(final boolean durableSubscription) {
 		this.durableSubscription = durableSubscription;
 	}
 
@@ -132,7 +135,7 @@ public class RabbitConsumerProperties {
 		return republishToDlq;
 	}
 
-	public void setRepublishToDlq(boolean republishToDlq) {
+	public void setRepublishToDlq(final boolean republishToDlq) {
 		this.republishToDlq = republishToDlq;
 	}
 
@@ -140,7 +143,7 @@ public class RabbitConsumerProperties {
 		return requeueRejected;
 	}
 
-	public void setRequeueRejected(boolean requeueRejected) {
+	public void setRequeueRejected(final boolean requeueRejected) {
 		this.requeueRejected = requeueRejected;
 	}
 
@@ -148,7 +151,7 @@ public class RabbitConsumerProperties {
 		return replyHeaderPatterns;
 	}
 
-	public void setReplyHeaderPatterns(String[] replyHeaderPatterns) {
+	public void setReplyHeaderPatterns(final String[] replyHeaderPatterns) {
 		this.replyHeaderPatterns = replyHeaderPatterns;
 	}
 
@@ -156,7 +159,15 @@ public class RabbitConsumerProperties {
 		return recoveryInterval;
 	}
 
-	public void setRecoveryInterval(long recoveryInterval) {
+	public void setRecoveryInterval(final long recoveryInterval) {
 		this.recoveryInterval = recoveryInterval;
+	}
+
+	public void setUseHashBindingKey(final boolean useHashBindingKey) {
+		this.useHashBindingKey = useHashBindingKey;
+	}
+
+	public boolean isUseHashBindingKey() {
+		return useHashBindingKey;
 	}
 }

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitConsumerProperties.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitConsumerProperties.java
@@ -36,8 +36,7 @@ public class RabbitConsumerProperties {
 
 	private int prefetch = 1;
 
-	private String[] requestHeaderPatterns = new String[] { "STANDARD_REQUEST_HEADERS",
-			"*" };
+	private String[] requestHeaderPatterns = new String[] {"STANDARD_REQUEST_HEADERS", "*"};
 
 	private int txSize = 1;
 
@@ -49,7 +48,7 @@ public class RabbitConsumerProperties {
 
 	private boolean requeueRejected = false;
 
-	private String[] replyHeaderPatterns = new String[] { "STANDARD_REPLY_HEADERS", "*" };
+	private String[] replyHeaderPatterns = new String[] {"STANDARD_REPLY_HEADERS", "*"};
 
 	private long recoveryInterval = 5000;
 
@@ -59,7 +58,7 @@ public class RabbitConsumerProperties {
 		return prefix;
 	}
 
-	public void setPrefix(final String prefix) {
+	public void setPrefix(String prefix) {
 		this.prefix = prefix;
 	}
 
@@ -67,7 +66,7 @@ public class RabbitConsumerProperties {
 		return transacted;
 	}
 
-	public void setTransacted(final boolean transacted) {
+	public void setTransacted(boolean transacted) {
 		this.transacted = transacted;
 	}
 
@@ -75,7 +74,7 @@ public class RabbitConsumerProperties {
 		return acknowledgeMode;
 	}
 
-	public void setAcknowledgeMode(final AcknowledgeMode acknowledgeMode) {
+	public void setAcknowledgeMode(AcknowledgeMode acknowledgeMode) {
 		Assert.notNull("Acknowledge mode cannot be null");
 		this.acknowledgeMode = acknowledgeMode;
 	}
@@ -85,7 +84,7 @@ public class RabbitConsumerProperties {
 		return maxConcurrency;
 	}
 
-	public void setMaxConcurrency(final int maxConcurrency) {
+	public void setMaxConcurrency(int maxConcurrency) {
 		this.maxConcurrency = maxConcurrency;
 	}
 
@@ -94,7 +93,7 @@ public class RabbitConsumerProperties {
 		return prefetch;
 	}
 
-	public void setPrefetch(final int prefetch) {
+	public void setPrefetch(int prefetch) {
 		this.prefetch = prefetch;
 	}
 
@@ -102,7 +101,7 @@ public class RabbitConsumerProperties {
 		return requestHeaderPatterns;
 	}
 
-	public void setRequestHeaderPatterns(final String[] requestHeaderPatterns) {
+	public void setRequestHeaderPatterns(String[] requestHeaderPatterns) {
 		this.requestHeaderPatterns = requestHeaderPatterns;
 	}
 
@@ -111,7 +110,7 @@ public class RabbitConsumerProperties {
 		return txSize;
 	}
 
-	public void setTxSize(final int txSize) {
+	public void setTxSize(int txSize) {
 		this.txSize = txSize;
 	}
 
@@ -119,7 +118,7 @@ public class RabbitConsumerProperties {
 		return autoBindDlq;
 	}
 
-	public void setAutoBindDlq(final boolean autoBindDlq) {
+	public void setAutoBindDlq(boolean autoBindDlq) {
 		this.autoBindDlq = autoBindDlq;
 	}
 
@@ -127,7 +126,7 @@ public class RabbitConsumerProperties {
 		return durableSubscription;
 	}
 
-	public void setDurableSubscription(final boolean durableSubscription) {
+	public void setDurableSubscription(boolean durableSubscription) {
 		this.durableSubscription = durableSubscription;
 	}
 
@@ -135,7 +134,7 @@ public class RabbitConsumerProperties {
 		return republishToDlq;
 	}
 
-	public void setRepublishToDlq(final boolean republishToDlq) {
+	public void setRepublishToDlq(boolean republishToDlq) {
 		this.republishToDlq = republishToDlq;
 	}
 
@@ -143,7 +142,7 @@ public class RabbitConsumerProperties {
 		return requeueRejected;
 	}
 
-	public void setRequeueRejected(final boolean requeueRejected) {
+	public void setRequeueRejected(boolean requeueRejected) {
 		this.requeueRejected = requeueRejected;
 	}
 
@@ -151,7 +150,7 @@ public class RabbitConsumerProperties {
 		return replyHeaderPatterns;
 	}
 
-	public void setReplyHeaderPatterns(final String[] replyHeaderPatterns) {
+	public void setReplyHeaderPatterns(String[] replyHeaderPatterns) {
 		this.replyHeaderPatterns = replyHeaderPatterns;
 	}
 
@@ -159,11 +158,11 @@ public class RabbitConsumerProperties {
 		return recoveryInterval;
 	}
 
-	public void setRecoveryInterval(final long recoveryInterval) {
+	public void setRecoveryInterval(long recoveryInterval) {
 		this.recoveryInterval = recoveryInterval;
 	}
 
-	public void setUseHashBindingKey(final boolean useHashBindingKey) {
+	public void setUseHashBindingKey(boolean useHashBindingKey) {
 		this.useHashBindingKey = useHashBindingKey;
 	}
 

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -292,9 +292,13 @@ public class RabbitMessageChannelBinder
 			String bindingKey = String.format("%s-%d", name, properties.getInstanceIndex());
 			declareBinding(queue.getName(), BindingBuilder.bind(queue).to(exchange).with(bindingKey));
 		}
-		else {
+		else if(properties.getExtension().isUseHashBindingKey()){
 			declareBinding(queue.getName(), BindingBuilder.bind(queue).to(exchange).with("#"));
 		}
+		else {
+			declareBinding(queue.getName(), BindingBuilder.bind(queue).to(exchange).with(name));
+		}
+		
 		if (durable) {
 			autoBindDLQ(applyPrefix(properties.getExtension().getPrefix(), baseQueueName), queueName,
 					properties.getExtension().getPrefix(), properties.getExtension().isAutoBindDlq());


### PR DESCRIPTION
Add new binding consumer property (default is true). Now you can disable to use hash binding key if declare a anonymous queue. 
If you don't use the hash binding key, the name (exchange name without
prefix) is used.

Solve issue #18