### PR TITLE
Add new property to set the routing key for an anonymous queue

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitConsumerProperties.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitConsumerProperties.java
@@ -52,6 +52,8 @@ public class RabbitConsumerProperties {
 
 	private long recoveryInterval = 5000;
 
+	private String routingKey = "#";
+
 	public String getPrefix() {
 		return prefix;
 	}
@@ -159,4 +161,13 @@ public class RabbitConsumerProperties {
 	public void setRecoveryInterval(long recoveryInterval) {
 		this.recoveryInterval = recoveryInterval;
 	}
+
+	public void setRoutingKey(String routingKey) {
+		this.routingKey = routingKey;
+	}
+
+	public String getRoutingKey() {
+		return routingKey;
+	}
+
 }

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -293,7 +293,8 @@ public class RabbitMessageChannelBinder
 			declareBinding(queue.getName(), BindingBuilder.bind(queue).to(exchange).with(bindingKey));
 		}
 		else {
-			declareBinding(queue.getName(), BindingBuilder.bind(queue).to(exchange).with("#"));
+			String routingKey = properties.getExtension().getRoutingKey();
+			declareBinding(queue.getName(), BindingBuilder.bind(queue).to(exchange).with(routingKey));
 		}
 		if (durable) {
 			autoBindDLQ(applyPrefix(properties.getExtension().getPrefix(), baseQueueName), queueName,


### PR DESCRIPTION
Add new binding consumer property to set the routing key for  anonymous queue (default is #).

Solve issue #18

Signed-off-by: SirWayne dennis.melzer@bosch-si.com
