### PR TITLE
Update with fixes missing from the 1.0.x line

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitBinderConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,18 +24,33 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "spring.cloud.stream.rabbit.binder")
 class RabbitBinderConfigurationProperties {
 
-	private String[] adminAdresses = new String[0];
+	private String[] adminAddresses = new String[0];
 
 	private String[] nodes = new String[0];
 
 	private int compressionLevel;
 
-	public String[] getAdminAdresses() {
-		return adminAdresses;
+	public String[] getAdminAddresses() {
+		return adminAddresses;
 	}
 
-	public void setAdminAdresses(String[] adminAdresses) {
-		this.adminAdresses = adminAdresses;
+	public void setAdminAddresses(String[] adminAddresses) {
+		this.adminAddresses = adminAddresses;
+	}
+
+	/**
+	 * @param adminAddresses A comma-separated list of RabbitMQ management plugin URLs.
+	 * @deprecated in favor of {@link #setAdminAddresses(String[])}. Will be removed in a
+	 * future release.
+	 */
+	@Deprecated
+	public void setAdminAdresses(String[] adminAddresses) {
+		setAdminAddresses(adminAddresses);
+	}
+
+	@Deprecated
+	public String[] getAdminAdresses() {
+		return this.adminAddresses;
 	}
 
 	public String[] getNodes() {

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
@@ -63,7 +63,7 @@ public class RabbitMessageChannelBinderConfiguration {
 	RabbitMessageChannelBinder rabbitMessageChannelBinder() {
 		RabbitMessageChannelBinder binder = new RabbitMessageChannelBinder(rabbitConnectionFactory, rabbitProperties);
 		binder.setCodec(codec);
-		binder.setAdminAddresses(rabbitBinderConfigurationProperties.getAdminAdresses());
+		binder.setAdminAddresses(rabbitBinderConfigurationProperties.getAdminAddresses());
 		binder.setCompressingPostProcessor(gZipPostProcessor());
 		binder.setDecompressingPostProcessor(deCompressingPostProcessor());
 		binder.setNodes(rabbitBinderConfigurationProperties.getNodes());

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -20,11 +20,13 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.health.RabbitHealthIndicator;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
-import org.springframework.boot.autoconfigure.cloud.CloudAutoConfiguration;
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.Cloud;
 import org.springframework.cloud.CloudFactory;
 import org.springframework.cloud.stream.binder.Binder;
@@ -41,11 +43,11 @@ import org.springframework.context.annotation.Profile;
  * @author Glenn Renfro
  * @author David Turanski
  * @author Eric Bottard
+ * @author Marius Bogoevici
  */
 @Configuration
 @ConditionalOnMissingBean(Binder.class)
 @Import(RabbitMessageChannelBinderConfiguration.class)
-@AutoConfigureBefore({CloudAutoConfiguration.class, RabbitAutoConfiguration.class})
 public class RabbitServiceAutoConfiguration {
 
 	@Bean
@@ -53,26 +55,83 @@ public class RabbitServiceAutoConfiguration {
 		return new RabbitHealthIndicator(rabbitTemplate);
 	}
 
+	/**
+	 * Configuration to be used when the cloud profile is set.
+	 */
 	@Configuration
 	@Profile("cloud")
-	@ConditionalOnClass(Cloud.class)
-	protected static class CloudConfig {
+	protected static class CloudProfile {
 
-		@Bean
-		public Cloud cloud() {
-			return new CloudFactory().getCloud();
+		/**
+		 * Configuration to be used when the cloud profile is set, and Cloud Connectors
+		 * are found on the classpath.
+		 */
+		@Configuration
+		@ConditionalOnClass(Cloud.class)
+		protected static class CloudConnectors {
+
+			@Bean
+			public Cloud cloud() {
+				return new CloudFactory().getCloud();
+			}
+
+			/**
+			 * Active only if {@code spring.cloud.stream.overrideCloudConnectors} is not
+			 * set to {@code true}.
+			 */
+			@Configuration
+			@ConditionalOnProperty(value = "spring.cloud.stream.overrideCloudConnectors", havingValue = "false", matchIfMissing = true)
+			// Required to parse Rabbit properties which are passed to the binder for
+			// clustering. We need to enable it here explicitly as the default Rabbit
+			// configuration is not triggered.
+			@EnableConfigurationProperties(RabbitProperties.class)
+			protected static class UseCloudConnectors {
+
+				/**
+				 * Creates a {@link ConnectionFactory} using the singleton service
+				 * connector.
+				 *
+				 * @param cloud {@link Cloud} instance to be used for accessing services.
+				 * @return the {@link ConnectionFactory} used by the binder.
+				 */
+				@Bean
+				ConnectionFactory rabbitConnectionFactory(Cloud cloud) {
+					return cloud.getSingletonServiceConnector(ConnectionFactory.class, null);
+				}
+
+				@Bean
+				@ConditionalOnMissingBean(RabbitTemplate.class)
+				RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+					return new RabbitTemplate(connectionFactory);
+				}
+			}
+
+			/**
+			 * Configuration to be used if
+			 * {@code spring.cloud.stream.overrideCloudConnectors} is set to {@code true}.
+			 * Defers to Spring Boot Autoconfiguration.
+			 */
+			@Configuration
+			@ConditionalOnProperty("spring.cloud.stream.overrideCloudConnectors")
+			@Import(RabbitAutoConfiguration.class)
+			protected static class OverrideCloudConnectors {
+			}
 		}
 
-		@Bean
-		@ConditionalOnMissingBean(ConnectionFactory.class)
-		ConnectionFactory rabbitConnectionFactory(Cloud cloud) {
-			return cloud.getSingletonServiceConnector(ConnectionFactory.class, null);
+		@Configuration
+		@ConditionalOnMissingClass("org.springframework.cloud.Cloud")
+		@Import(RabbitAutoConfiguration.class)
+		protected static class NoCloudConnectors {
 		}
 	}
 
+	/**
+	 * Configuration to be used when the cloud profile is not set. Defer to Spring Boot
+	 * autoconfiguration.
+	 */
 	@Configuration
 	@Profile("!cloud")
 	@Import(RabbitAutoConfiguration.class)
-	protected static class NoCloudConfig {
+	protected static class NoCloudProfile {
 	}
 }


### PR DESCRIPTION
Fixes #28

In the process of binder migration, a number of fixes from the
main branch have been ignored. This adds the changes
done in the following commits in the 1.0.x branch:

https://github.com/spring-cloud/spring-cloud-stream/commit/228f24e03440aab3ac4467c7cab1b7a944b1ad2e
https://github.com/spring-cloud/spring-cloud-stream/commit/bc5b7f95f73514b7b67de0bec86c9b773ee84eed
https://github.com/spring-cloud/spring-cloud-stream/commit/65f04c7a8bc4297e223e45f87402196e92064346