### PR TITLE
GH-34: Support User Infrastructure and Delayed Ex.

### DIFF
--- a/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
@@ -100,11 +100,33 @@ autoBindDlq::
   Whether to automatically declare the DLQ and bind it to the binder DLX.
 +
 Default: `false`.
+bindQueue::
+  Whether to bind the queue to the destination exchange; set to false if you have set up your own infrastructure and have previously created/bound the queue.
++
+Default: `true`.
+declareExchange::
+  Whether to declare the exchange for the destination.
++
+Default: `true`.
+delayedExchange::
+  Whether to declare the exchange as a `Delayed Message Exchange` - requires the delayed message exchange plugin on the broker.
+  The `x-delayed-type` argument is set to the `exchangeType`.
++
+Default: `false`.
 durableSubscription::
   Whether subscription should be durable.
 Only effective if `group` is also set.
 +
 Default: `true`.
+exchangeRoutingKey::
+  The routing key with which to bind the queue to the exchange (if `bindQueue` is `true`).
+  Only applies to non-partitioned destinations.
++
+Default: `#`.
+exchangeType::
+  The exchange type; `direct`, `fanout` or `topic` for non-partitioned destinations; `direct` or `topic` for partitioned destinations.
++
+Default: `topic`.
 maxConcurrency::
   Default: `1`.
 prefetch::
@@ -167,18 +189,41 @@ batchBufferLimit::
   Default: `10000`.
 batchTimeout::
   Default: `5000`.
+bindQueue::
+  Whether to bind the queue to the destination exchange; set to false if you have set up your own infrastructure and have previously created/bound the queue.
+  Only applies if `requiredGroups` are provided.
++
+Default: `true`.
 compress::
   Whether data should be compressed when sent.
 +
 Default: `false`.
-transacted::
-  Whether to use transacted channels.
+declareExchange::
+  Whether to declare the exchange for the destination.
+  Only applies if `requiredGroups` are provided.
++
+Default: `true`.
+delayedExchange::
+  Whether to declare the exchange as a `Delayed Message Exchange` - requires the delayed message exchange plugin on the broker.
+  The `x-delayed-type` argument is set to the `exchangeType`.
+  Only applies if `requiredGroups` are provided.
 +
 Default: `false`.
 deliveryMode::
   Delivery mode.
 +
 Default: `PERSISTENT`.
+exchangeRoutingKey::
+  The routing key with which to bind the queue to the exchange (if `bindQueue` is `true`).
+  Only applies to non-partitioned destinations.
+  Only applies if `requiredGroups` are provided.
++
+Default: `#`.
+exchangeType::
+  The exchange type; `direct`, `fanout` or `topic` for non-partitioned destinations; `direct` or `topic` for partitioned destinations.
+  Only applies if `requiredGroups` are provided.
++
+Default: `topic`.
 prefix::
   A prefix to be added to the name of the `destination` exchange.
 +
@@ -191,6 +236,10 @@ replyHeaderPatterns::
   The reply headers to be transported.
 +
 Default: `[STANDARD_REPLY_HEADERS,'*']`.
+transacted::
+  Whether to use transacted channels.
++
+Default: `false`.
 
 [NOTE]
 ====

--- a/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
@@ -118,9 +118,9 @@ durableSubscription::
 Only effective if `group` is also set.
 +
 Default: `true`.
-exchangeRoutingKey::
+bindingRoutingKey::
   The routing key with which to bind the queue to the exchange (if `bindQueue` is `true`).
-  Only applies to non-partitioned destinations.
+  for partitioned destinations `-<instanceIndex>` will be appended.
 +
 Default: `#`.
 exchangeType::
@@ -191,7 +191,7 @@ batchTimeout::
   Default: `5000`.
 bindQueue::
   Whether to bind the queue to the destination exchange; set to false if you have set up your own infrastructure and have previously created/bound the queue.
-  Only applies if `requiredGroups` are provided.
+  Only applies if `requiredGroups` are provided and then only to those groups.
 +
 Default: `true`.
 compress::
@@ -202,6 +202,10 @@ declareExchange::
   Whether to declare the exchange for the destination.
 +
 Default: `true`.
+delay::
+  A SpEL expression to evaluate the delay to apply to the message (`x-delay` header) - has no effect if the exchange is not a delayed message exchange.
++
+Default: No `x-delay` header is set.
 delayedExchange::
   Whether to declare the exchange as a `Delayed Message Exchange` - requires the delayed message exchange plugin on the broker.
   The `x-delayed-type` argument is set to the `exchangeType`.
@@ -233,6 +237,10 @@ replyHeaderPatterns::
   The reply headers to be transported.
 +
 Default: `[STANDARD_REPLY_HEADERS,'*']`.
+routingKeyExpression::
+  A SpEL expression to determine the routing key to use when publishing messages.
++
+Default: `destination` or `destination-<partition>` for partitioned destinations.
 transacted::
   Whether to use transacted channels.
 +

--- a/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
@@ -200,13 +200,11 @@ compress::
 Default: `false`.
 declareExchange::
   Whether to declare the exchange for the destination.
-  Only applies if `requiredGroups` are provided.
 +
 Default: `true`.
 delayedExchange::
   Whether to declare the exchange as a `Delayed Message Exchange` - requires the delayed message exchange plugin on the broker.
   The `x-delayed-type` argument is set to the `exchangeType`.
-  Only applies if `requiredGroups` are provided.
 +
 Default: `false`.
 deliveryMode::
@@ -221,7 +219,6 @@ exchangeRoutingKey::
 Default: `#`.
 exchangeType::
   The exchange type; `direct`, `fanout` or `topic` for non-partitioned destinations; `direct` or `topic` for partitioned destinations.
-  Only applies if `requiredGroups` are provided.
 +
 Default: `topic`.
 prefix::

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitCommonProperties.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitCommonProperties.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.rabbit;
+
+import org.springframework.amqp.core.ExchangeTypes;
+
+/**
+ * @author Gary Russell
+ * @since 1.2
+ *
+ */
+public abstract class RabbitCommonProperties {
+
+	/**
+	 * type of exchange to declare (if necessary, and declareExchange is true).
+	 */
+	private String exchangeType = ExchangeTypes.TOPIC;
+
+	/**
+	 * whether to declare the exchange
+	 */
+	private boolean declareExchange = true;
+
+	/**
+	 * whether a delayed message exchange should be used
+	 */
+	private boolean delayedExchange = false;
+
+	/**
+	 * whether to bind a queue (or queues when partitioned) to the exchange
+	 */
+	private boolean bindQueue = true;
+
+	/**
+	 * The routing key to bind
+	 */
+	private String exchangeRoutingKey = "#";
+
+	public String getExchangeType() {
+		return this.exchangeType;
+	}
+
+	public void setExchangeType(String exchangeType) {
+		this.exchangeType = exchangeType;
+	}
+
+	public boolean isDeclareExchange() {
+		return this.declareExchange;
+	}
+
+	public void setDeclareExchange(boolean declareExchange) {
+		this.declareExchange = declareExchange;
+	}
+
+	public boolean isDelayedExchange() {
+		return this.delayedExchange;
+	}
+
+	public void setDelayedExchange(boolean delayedExchange) {
+		this.delayedExchange = delayedExchange;
+	}
+
+	public boolean isBindQueue() {
+		return this.bindQueue;
+	}
+
+	public void setBindQueue(boolean bindQueue) {
+		this.bindQueue = bindQueue;
+	}
+
+	public String getExchangeRoutingKey() {
+		return this.exchangeRoutingKey;
+	}
+
+	public void setExchangeRoutingKey(String routingKey) {
+		this.exchangeRoutingKey = routingKey;
+	}
+
+}

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitCommonProperties.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitCommonProperties.java
@@ -46,9 +46,9 @@ public abstract class RabbitCommonProperties {
 	private boolean bindQueue = true;
 
 	/**
-	 * The routing key to bind
+	 * The routing key to bind (default # for non-partitioned, destination-instanceIndex for partitioned)
 	 */
-	private String exchangeRoutingKey = "#";
+	private String bindingRoutingKey;
 
 	public String getExchangeType() {
 		return this.exchangeType;
@@ -82,12 +82,12 @@ public abstract class RabbitCommonProperties {
 		this.bindQueue = bindQueue;
 	}
 
-	public String getExchangeRoutingKey() {
-		return this.exchangeRoutingKey;
+	public String getBindingRoutingKey() {
+		return this.bindingRoutingKey;
 	}
 
-	public void setExchangeRoutingKey(String routingKey) {
-		this.exchangeRoutingKey = routingKey;
+	public void setBindingRoutingKey(String routingKey) {
+		this.bindingRoutingKey = routingKey;
 	}
 
 }

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitConsumerProperties.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitConsumerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,9 @@ import org.springframework.util.Assert;
 
 /**
  * @author Marius Bogoevici
+ * @author Gary Russell
  */
-public class RabbitConsumerProperties {
+public class RabbitConsumerProperties extends RabbitCommonProperties {
 
 	private String prefix = "";
 

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitProducerProperties.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitProducerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.amqp.core.MessageDeliveryMode;
  * @author Marius Bogoevici
  * @author Gary Russell
  */
-public class RabbitProducerProperties {
+public class RabbitProducerProperties extends RabbitCommonProperties {
 
 	private String prefix = "";
 

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitProducerProperties.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitProducerProperties.java
@@ -48,6 +48,16 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 
 	private String[] replyHeaderPatterns = new String[] {"STANDARD_REPLY_HEADERS", "*"};
 
+	/**
+	 * When using a delayed message exchange, a SpEL expression to determine the delay to apply to messages
+	 */
+	private String delayExpression;
+
+	/**
+	 * A custom routing key when publishing messages; default is the destination name; suffixed by "-partition" when partitioned
+	 */
+	private String routingKeyExpression;
+
 	public String getPrefix() {
 		return prefix;
 	}
@@ -137,6 +147,22 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 
 	public void setTransacted(boolean transacted) {
 		this.transacted = transacted;
+	}
+
+	public String getDelayExpression() {
+		return this.delayExpression;
+	}
+
+	public void setDelayExpression(String delayExpression) {
+		this.delayExpression = delayExpression;
+	}
+
+	public String getRoutingKeyExpression() {
+		return this.routingKeyExpression;
+	}
+
+	public void setRoutingKeyExpression(String routingKeyExpression) {
+		this.routingKeyExpression = routingKeyExpression;
 	}
 
 }

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestBinder.java
@@ -74,6 +74,7 @@ public class RabbitTestBinder extends AbstractTestBinder<RabbitMessageChannelBin
 			this.queues.add(properties.getExtension().getPrefix() + name + ("." + group));
 		}
 		this.exchanges.add(properties.getExtension().getPrefix() + name);
+		this.prefixes.add(properties.getExtension().getPrefix());
 		return super.bindConsumer(name, group, moduleInputChannel, properties);
 	}
 
@@ -82,6 +83,12 @@ public class RabbitTestBinder extends AbstractTestBinder<RabbitMessageChannelBin
 			ExtendedProducerProperties<RabbitProducerProperties> properties) {
 		this.queues.add(properties.getExtension().getPrefix() + name + ".default");
 		this.exchanges.add(properties.getExtension().getPrefix() + name);
+		if (properties.getRequiredGroups() != null) {
+			for (String group : properties.getRequiredGroups()) {
+				this.queues.add(properties.getExtension().getPrefix() + name + "." + group);
+			}
+		}
+		this.prefixes.add(properties.getExtension().getPrefix());
 		return super.bindProducer(name, moduleOutputChannel, properties);
 	}
 


### PR DESCRIPTION
Resolves #34
Resolves #26

- Add properties to support user configuration of exchanges/queues
-- Disable binding and exchange declaration, giving complete control
-- Allow the exchange type to be specified and, for non-partitioned destinations, the routing key.
- Add support for the Delayed Message Exchange broker plugin