### PR TITLE
Fix RK Expression for Partitioned Streams

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -16,6 +16,11 @@
 
 package org.springframework.cloud.stream.binder.rabbit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,11 +28,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.Deflater;
 
-import com.rabbitmq.http.client.domain.QueueInfo;
 import org.aopalliance.aop.Advice;
 import org.apache.commons.logging.Log;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.amqp.core.AcknowledgeMode;
@@ -73,10 +78,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.GenericMessage;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.rabbitmq.http.client.domain.QueueInfo;
 
 /**
  * @author Mark Fisher
@@ -93,6 +95,9 @@ public class RabbitBinderTests extends
 	@Rule
 	public RabbitTestSupport rabbitAvailableRule = new RabbitTestSupport(true);
 
+	@Rule
+	public TestName testName = new TestName();
+
 	@Override
 	protected RabbitTestBinder getBinder() {
 		if (testBinder == null) {
@@ -108,7 +113,12 @@ public class RabbitBinderTests extends
 
 	@Override
 	protected ExtendedProducerProperties<RabbitProducerProperties> createProducerProperties() {
-		return new ExtendedProducerProperties<>(new RabbitProducerProperties());
+		ExtendedProducerProperties<RabbitProducerProperties> props = new ExtendedProducerProperties<>(
+				new RabbitProducerProperties());
+		if (testName.getMethodName().equals("testPartitionedModuleSpEL")) {
+			props.getExtension().setRoutingKeyExpression("'part.0'");
+		}
+		return props;
 	}
 
 	@Override
@@ -386,8 +396,7 @@ public class RabbitBinderTests extends
 		producerBinding = binder.bindProducer("props.0", channel,
 				producerProperties);
 		endpoint = extractEndpoint(producerBinding);
-		assertThat(TestUtils.getPropertyValue(endpoint, "routingKeyExpression", SpelExpression.class)
-				.getExpressionString()).isEqualTo("'props.0-' + headers['partition']");
+		assertThat(getEndpointRouting(endpoint)).isEqualTo("'props.0-' + headers['partition']");
 		assertThat(TestUtils.getPropertyValue(endpoint, "delayExpression", SpelExpression.class)
 				.getExpressionString()).isEqualTo("42");
 		mode = TestUtils.getPropertyValue(endpoint, "defaultDeliveryMode", MessageDeliveryMode.class);
@@ -1058,6 +1067,12 @@ public class RabbitBinderTests extends
 	@Override
 	protected String getClassUnderTestName() {
 		return CLASS_UNDER_TEST_NAME;
+	}
+
+	@Override
+	protected void checkRkExpression(Object endpoint) {
+		assertThat(getEndpointRouting(endpoint))
+			.contains(getExpectedRoutingBaseDestination("'part.0'", "test") + " + '-' + headers['partition']");
 	}
 
 	@Override

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -1070,7 +1070,7 @@ public class RabbitBinderTests extends
 	}
 
 	@Override
-	protected void checkRkExpression(Object endpoint) {
+	protected void checkRkExpressionForPartitionedModuleSpEL(Object endpoint) {
 		assertThat(getEndpointRouting(endpoint))
 			.contains(getExpectedRoutingBaseDestination("'part.0'", "test") + " + '-' + headers['partition']");
 	}


### PR DESCRIPTION
Fixes #43

The final routing key expression was incorrect when the stream is partitioned and
the user supplied a base for the routing key expression.

Depends on https://github.com/spring-cloud/spring-cloud-stream/pull/801