### PR TITLE
Revert to Durable Exchanges by default

### DIFF
--- a/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
@@ -100,6 +100,11 @@ autoBindDlq::
   Whether to automatically declare the DLQ and bind it to the binder DLX.
 +
 Default: `false`.
+bindingRoutingKey::
+  The routing key with which to bind the queue to the exchange (if `bindQueue` is `true`).
+  for partitioned destinations `-<instanceIndex>` will be appended.
++
+Default: `#`.
 bindQueue::
   Whether to bind the queue to the destination exchange; set to `false` if you have set up your own infrastructure and have previously created/bound the queue.
 +
@@ -118,11 +123,14 @@ durableSubscription::
 Only effective if `group` is also set.
 +
 Default: `true`.
-bindingRoutingKey::
-  The routing key with which to bind the queue to the exchange (if `bindQueue` is `true`).
-  for partitioned destinations `-<instanceIndex>` will be appended.
+exchangeAutoDelete::
+  If `declareExchange` is true, whether the exchange should be auto-delete (removed after the last queue is removed).
 +
-Default: `#`.
+Default: `true`.
+exchangeDurable::
+  If `declareExchange` is true, whether the exchange should be durable (survives broker restart).
++
+Default: `true`.
 exchangeType::
   The exchange type; `direct`, `fanout` or `topic` for non-partitioned destinations; `direct` or `topic` for partitioned destinations.
 +
@@ -189,6 +197,12 @@ batchBufferLimit::
   Default: `10000`.
 batchTimeout::
   Default: `5000`.
+bindingRoutingKey::
+  The routing key with which to bind the queue to the exchange (if `bindQueue` is `true`).
+  Only applies to non-partitioned destinations.
+  Only applies if `requiredGroups` are provided and then only to those groups.
++
+Default: `#`.
 bindQueue::
   Whether to bind the queue to the destination exchange; set to `false` if you have set up your own infrastructure and have previously created/bound the queue.
   Only applies if `requiredGroups` are provided and then only to those groups.
@@ -215,12 +229,14 @@ deliveryMode::
   Delivery mode.
 +
 Default: `PERSISTENT`.
-exchangeRoutingKey::
-  The routing key with which to bind the queue to the exchange (if `bindQueue` is `true`).
-  Only applies to non-partitioned destinations.
-  Only applies if `requiredGroups` are provided.
+exchangeAutoDelete::
+  If `declareExchange` is true, whether the exchange should be auto-delete (removed after the last queue is removed).
 +
-Default: `#`.
+Default: `true`.
+exchangeDurable::
+  If `declareExchange` is true, whether the exchange should be durable (survives broker restart).
++
+Default: `true`.
 exchangeType::
   The exchange type; `direct`, `fanout` or `topic` for non-partitioned destinations; `direct` or `topic` for partitioned destinations.
 +

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitCommonProperties.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitCommonProperties.java
@@ -26,7 +26,7 @@ import org.springframework.amqp.core.ExchangeTypes;
 public abstract class RabbitCommonProperties {
 
 	/**
-	 * type of exchange to declare (if necessary, and declareExchange is true).
+	 * type of exchange to declare (if necessary, and declareExchange is true)
 	 */
 	private String exchangeType = ExchangeTypes.TOPIC;
 
@@ -39,6 +39,15 @@ public abstract class RabbitCommonProperties {
 	 * whether a delayed message exchange should be used
 	 */
 	private boolean delayedExchange = false;
+
+	/**
+	 * whether to declare the exchange as durable
+	 */
+	private boolean exchangeDurable = true;
+	/**
+	 * whether to declare the exchange as auto-delete
+	 */
+	private boolean exchangeAutoDelete = false;
 
 	/**
 	 * whether to bind a queue (or queues when partitioned) to the exchange
@@ -72,6 +81,22 @@ public abstract class RabbitCommonProperties {
 
 	public void setDelayedExchange(boolean delayedExchange) {
 		this.delayedExchange = delayedExchange;
+	}
+
+	public boolean isExchangeDurable() {
+		return exchangeDurable;
+	}
+
+	public void setExchangeDurable(boolean exchangeDurable) {
+		this.exchangeDurable = exchangeDurable;
+	}
+
+	public boolean isExchangeAutoDelete() {
+		return exchangeAutoDelete;
+	}
+
+	public void setExchangeAutoDelete(boolean exchangeAutoDelete) {
+		this.exchangeAutoDelete = exchangeAutoDelete;
 	}
 
 	public boolean isBindQueue() {

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -481,6 +481,12 @@ public class RabbitMessageChannelBinder
 			Constructor<ExchangeBuilder> ctor = ExchangeBuilder.class.getDeclaredConstructor(String.class, String.class);
 			ReflectionUtils.makeAccessible(ctor);
 			ExchangeBuilder builder = ctor.newInstance(exchangeName, properties.getExchangeType());
+			if (properties.isExchangeDurable()) {
+				builder.durable();
+			}
+			if (properties.isExchangeAutoDelete()) {
+				builder.autoDelete();
+			}
 			if (properties.isDelayedExchange()) {
 				builder.delayed();
 			}

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -266,6 +266,8 @@ public class RabbitBinderTests extends
 			exchange = rmt.getExchange("propsUser2");
 		}
 		assertThat(exchange).isInstanceOf(DirectExchange.class);
+		assertThat(exchange.isDurable()).isEqualTo(true);
+		assertThat(exchange.isAutoDelete()).isEqualTo(false);
 	}
 
 	@Test


### PR DESCRIPTION
Fix #48 for 1.1.x branch

The commit for #34 inadvertently set the exchange to be non-durable (won't survive a broker restart).

Revert to durable exchanges by default and add a configuration option.

Also add an option to auto-delete the exchange.

Update documentation