### PR TITLE
GH-9: Remove request/replyHeaderPatterns

### DIFF
--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitConsumerProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitConsumerProperties.java
@@ -35,8 +35,6 @@ public class RabbitConsumerProperties extends RabbitCommonProperties {
 
 	private int prefetch = 1;
 
-	private String[] requestHeaderPatterns = new String[] {"STANDARD_REQUEST_HEADERS", "*"};
-
 	private int txSize = 1;
 
 	private boolean durableSubscription = true;
@@ -45,7 +43,7 @@ public class RabbitConsumerProperties extends RabbitCommonProperties {
 
 	private boolean requeueRejected = false;
 
-	private String[] replyHeaderPatterns = new String[] {"STANDARD_REPLY_HEADERS", "*"};
+	private String[] headerPatterns = new String[] {"*"};
 
 	private long recoveryInterval = 5000;
 
@@ -84,12 +82,22 @@ public class RabbitConsumerProperties extends RabbitCommonProperties {
 		this.prefetch = prefetch;
 	}
 
+	/**
+	 * @deprecated - use {@link #getHeaderPatterns()}.
+	 * @return the header patterns.
+	 */
+	@Deprecated
 	public String[] getRequestHeaderPatterns() {
-		return requestHeaderPatterns;
+		return this.headerPatterns;
 	}
 
+	/**
+	 * @deprecated - use {@link #setHeaderPatterns(String[])}.
+	 * @param requestHeaderPatterns
+	 */
+	@Deprecated
 	public void setRequestHeaderPatterns(String[] requestHeaderPatterns) {
-		this.requestHeaderPatterns = requestHeaderPatterns;
+		this.headerPatterns = requestHeaderPatterns;
 	}
 
 	@Min(value = 1, message = "Tx Size should be greater than zero.")
@@ -125,12 +133,12 @@ public class RabbitConsumerProperties extends RabbitCommonProperties {
 		this.requeueRejected = requeueRejected;
 	}
 
-	public String[] getReplyHeaderPatterns() {
-		return replyHeaderPatterns;
+	public String[] getHeaderPatterns() {
+		return headerPatterns;
 	}
 
-	public void setReplyHeaderPatterns(String[] replyHeaderPatterns) {
-		this.replyHeaderPatterns = replyHeaderPatterns;
+	public void setHeaderPatterns(String[] replyHeaderPatterns) {
+		this.headerPatterns = replyHeaderPatterns;
 	}
 
 	public long getRecoveryInterval() {

--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
@@ -26,8 +26,6 @@ import org.springframework.amqp.core.MessageDeliveryMode;
  */
 public class RabbitProducerProperties extends RabbitCommonProperties {
 
-	private String[] requestHeaderPatterns = new String[] {"STANDARD_REQUEST_HEADERS", "*"};
-
 	private boolean compress;
 
 	private boolean batchingEnabled;
@@ -42,7 +40,7 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 
 	private MessageDeliveryMode deliveryMode = MessageDeliveryMode.PERSISTENT;
 
-	private String[] replyHeaderPatterns = new String[] {"STANDARD_REPLY_HEADERS", "*"};
+	private String[] headerPatterns = new String[] {"*"};
 
 	/**
 	 * When using a delayed message exchange, a SpEL expression to determine the delay to apply to messages
@@ -54,12 +52,22 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 	 */
 	private String routingKeyExpression;
 
+	/**
+	 * @deprecated - use {@link #setHeaderPatterns(String[])}.
+	 * @param requestHeaderPatterns the patterns.
+	 */
+	@Deprecated
 	public void setRequestHeaderPatterns(String[] requestHeaderPatterns) {
-		this.requestHeaderPatterns = requestHeaderPatterns;
+		this.headerPatterns = requestHeaderPatterns;
 	}
 
+	/**
+	 * @deprecated - use {@link #getHeaderPatterns()}.
+	 * @return the header patterns.
+	 */
+	@Deprecated
 	public String[] getRequestHeaderPatterns() {
-		return requestHeaderPatterns;
+		return this.headerPatterns;
 	}
 
 	public void setCompress(boolean compress) {
@@ -78,12 +86,12 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 		return deliveryMode;
 	}
 
-	public String[] getReplyHeaderPatterns() {
-		return replyHeaderPatterns;
+	public String[] getHeaderPatterns() {
+		return headerPatterns;
 	}
 
-	public void setReplyHeaderPatterns(String[] replyHeaderPatterns) {
-		this.replyHeaderPatterns = replyHeaderPatterns;
+	public void setHeaderPatterns(String[] replyHeaderPatterns) {
+		this.headerPatterns = replyHeaderPatterns;
 	}
 
 	public boolean isBatchingEnabled() {

--- a/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
@@ -179,6 +179,10 @@ expires::
   how long before an unused queue is deleted (ms)
 +
 Default: `no expiration`
+headerPatterns::
+  Patterns for headers to be mapped from inbound messages.
++
+Default: `['*']` (all headers).
 maxConcurrency::
   the maximum number of consumers
 +
@@ -211,14 +215,6 @@ requeueRejected::
   Whether delivery failures should be requeued when retry is disabled or republishToDlq is false.
 +
 Default: `false`.
-requestHeaderPatterns::
-  The request headers to be transported.
-+
-Default: `[STANDARD_REQUEST_HEADERS,'*']`.
-replyHeaderPatterns::
-  The reply headers to be transported.
-+
-Default: `[STANDARD_REPLY_HEADERS,'*']`.
 republishToDlq::
   By default, messages which fail after retries are exhausted are rejected.
 If a dead-letter queue (DLQ) is configured, RabbitMQ will route the failed message (unchanged) to the DLQ.
@@ -358,6 +354,10 @@ expires::
   Only applies if `requiredGroups` are provided and then only to those groups.
 +
 Default: `no expiration`
+headerPatterns::
+  Patterns for headers to be mapped to outbound messages.
++
+Default: `['*']` (all headers).
 maxLength::
   maximum number of messages in the queue
   Only applies if `requiredGroups` are provided and then only to those groups.
@@ -377,14 +377,6 @@ prefix::
   A prefix to be added to the name of the `destination` exchange.
 +
 Default: "".
-requestHeaderPatterns::
-  The request headers to be transported.
-+
-Default: `[STANDARD_REQUEST_HEADERS,'*']`.
-replyHeaderPatterns::
-  The reply headers to be transported.
-+
-Default: `[STANDARD_REPLY_HEADERS,'*']`.
 routingKeyExpression::
   A SpEL expression to determine the routing key to use when publishing messages.
 +


### PR DESCRIPTION
Resolves #9

Replace with simply `headerPatterns`.

The reply header patterns were never used and are removed.

The request header patterns are deprecated in favor of header patterns.

Requires https://github.com/spring-cloud/spring-cloud-stream/pull/857