### PR TITLE
Make RabbitHealthIndicator conditional

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -44,16 +44,12 @@ import org.springframework.context.annotation.Profile;
  * @author David Turanski
  * @author Eric Bottard
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 @Configuration
 @ConditionalOnMissingBean(Binder.class)
-@Import(RabbitMessageChannelBinderConfiguration.class)
+@Import({RabbitMessageChannelBinderConfiguration.class, RabbitServiceAutoConfiguration.RabbitHealthIndicatorConfiguration.class})
 public class RabbitServiceAutoConfiguration {
-
-	@Bean
-	public HealthIndicator binderHealthIndicator(RabbitTemplate rabbitTemplate) {
-		return new RabbitHealthIndicator(rabbitTemplate);
-	}
 
 	/**
 	 * Configuration to be used when the cloud profile is set.
@@ -133,5 +129,15 @@ public class RabbitServiceAutoConfiguration {
 	@Profile("!cloud")
 	@Import(RabbitAutoConfiguration.class)
 	protected static class NoCloudProfile {
+	}
+
+	@Configuration
+	@ConditionalOnClass(name = "org.springframework.boot.actuate.health.HealthIndicator")
+	public static class RabbitHealthIndicatorConfiguration {
+
+		@Bean
+		public HealthIndicator binderHealthIndicator(RabbitTemplate rabbitTemplate) {
+			return new RabbitHealthIndicator(rabbitTemplate);
+		}
 	}
 }


### PR DESCRIPTION
- When the spring-boot actuator is not in the classpath, the RabbitServiceAutoConfiguration should exclude RabbitHealthIndicator

Resolves #55