### PR TITLE
Do not create create a new `ConnectionFactory` if one already exists in parent

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -91,6 +91,7 @@ public class RabbitServiceAutoConfiguration {
 				 * @return the {@link ConnectionFactory} used by the binder.
 				 */
 				@Bean
+				@ConditionalOnMissingBean(ConnectionFactory.class)
 				ConnectionFactory rabbitConnectionFactory(Cloud cloud) {
 					return cloud.getSingletonServiceConnector(ConnectionFactory.class, null);
 				}


### PR DESCRIPTION
Fix #63

Make sure that the creation of a new `ConnectionFactory` when
cloud connectors are used is done only when the binder
context is not a child of the main context, otherwise inherit
the connection factory as usual. This ensures that its lifecycle
is in sync with the parent.