### PR TITLE
GH-67 removed dead code and fixed test

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -55,7 +55,6 @@ import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter;
 import org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
-import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.messaging.MessageChannel;
@@ -230,16 +229,12 @@ public class RabbitMessageChannelBinder
 	protected MessageProducer createConsumerEndpoint(ConsumerDestination consumerDestination, String group,
 													ExtendedConsumerProperties<RabbitConsumerProperties> properties) {
 
-		DirectChannel convertingBridgeChannel = new DirectChannel();
-		convertingBridgeChannel.setBeanFactory(this.getBeanFactory());
-
 		String prefix = properties.getExtension().getPrefix();
 		String destination = consumerDestination.getName();
 		String prefixStripped = (StringUtils.isEmpty(prefix) || !destination.startsWith(prefix)) ? destination
 				: destination.substring(prefix.length());
 		String baseQueueName = StringUtils.hasText(group) ? prefixStripped.substring(0, prefixStripped.indexOf(group)) + group : prefixStripped;
 
-		convertingBridgeChannel.setBeanName(baseQueueName + ".bridge");
 		SimpleMessageListenerContainer listenerContainer = new SimpleMessageListenerContainer(
 				this.connectionFactory);
 		listenerContainer.setAcknowledgeMode(properties.getExtension().getAcknowledgeMode());

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderCleanerTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderCleanerTests.java
@@ -136,10 +136,19 @@ public class RabbitBinderCleanerTests {
 				URI uri = UriComponentsBuilder.fromUriString("http://localhost:15672/api/queues").pathSegment(
 						"{vhost}", "{queue}")
 						.buildAndExpand("/", queueName).encode().toUri();
-				while (n++ < 100) {
-					@SuppressWarnings("unchecked")
+
+				Object consumers = null;
+				while (n++ < 100 && consumers == null) {
 					Map<String, Object> queueInfo = template.getForObject(uri, Map.class);
-					if (!queueInfo.get("consumers").equals(Integer.valueOf(state))) {
+					consumers = queueInfo.get("consumers");
+					if (consumers == null){
+						Thread.sleep(100);
+					}
+				}
+				assertThat(consumers != null);
+
+				while (n++ < 100) {
+					if (!consumers.equals(Integer.valueOf(state))) {
 						break;
 					}
 					Thread.sleep(100);


### PR DESCRIPTION
- removed dead code from RabbitMessageChannelBinder.createConsumerEndpoint(..)
- fixed RabbitBinderCleanerTests.testCleanStream()

Resolves #67