### PR TITLE
SCDF-GH-1528: Fix DLQ Routing Key for SCDF

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -846,15 +846,15 @@ public class RabbitBinderTests extends
 			}
 
 		});
-		Binding<MessageChannel> consumerBinding = binder.bindConsumer("dlqpubtest", "default", moduleInputChannel,
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer("foo.dlqpubtest", "foo", moduleInputChannel,
 				consumerProperties);
 
 		RabbitTemplate template = new RabbitTemplate(this.rabbitAvailableRule.getResource());
-		template.convertAndSend("", TEST_PREFIX + "dlqpubtest.default", "foo");
+		template.convertAndSend("", TEST_PREFIX + "foo.dlqpubtest.foo", "foo");
 
 		int n = 0;
 		while (n++ < 100) {
-			org.springframework.amqp.core.Message deadLetter = template.receive(TEST_PREFIX + "dlqpubtest.default.dlq");
+			org.springframework.amqp.core.Message deadLetter = template.receive(TEST_PREFIX + "foo.dlqpubtest.foo.dlq");
 			if (deadLetter != null) {
 				assertThat(new String(deadLetter.getBody())).isEqualTo("foo");
 				assertThat(deadLetter.getMessageProperties().getHeaders()).containsKey(("x-exception-stacktrace"));


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-dataflow#1528

Data flow creates destinations with name `<stream>.module` and sets the group to the stream name.
The rabbit binder binders a queue `<destination>.<group>` to the `<destination>` exchange.
If `autoBindDlq` is set, a DLQ is created and bound with key matching the original queue name.

There is logic manipulating the destination name to strip off the prefix (if any) because it's re-added later.

This logic doesn't work with SCDF because the group occurs twice in the queue name; we end up routing on
just the `<group>`.

Remove the strip and add back of the prefix to avoid this logic altogether.

Modify one of the tests to simulate SCDF naming.