### PR TITLE
GH-58, 80: Exclusive Consumer and Lazy Queues

### DIFF
--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitCommonProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitCommonProperties.java
@@ -149,6 +149,16 @@ public abstract class RabbitCommonProperties {
 	 */
 	private String prefix = "";
 
+	/**
+	 * True if the queue is provisioned as a lazy queue.
+	 */
+	private boolean lazy;
+
+	/**
+	 * True if the DLQ is provisioned as a lazy queue.
+	 */
+	private boolean dlqLazy;
+
 	public String getExchangeType() {
 		return this.exchangeType;
 	}
@@ -340,6 +350,22 @@ public abstract class RabbitCommonProperties {
 
 	public void setPrefix(String prefix) {
 		this.prefix = prefix;
+	}
+
+	public boolean isLazy() {
+		return this.lazy;
+	}
+
+	public void setLazy(boolean lazy) {
+		this.lazy = lazy;
+	}
+
+	public boolean isDlqLazy() {
+		return this.dlqLazy;
+	}
+
+	public void setDlqLazy(boolean dlqLazy) {
+		this.dlqLazy = dlqLazy;
 	}
 
 }

--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitConsumerProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitConsumerProperties.java
@@ -50,6 +50,11 @@ public class RabbitConsumerProperties extends RabbitCommonProperties {
 
 	private long recoveryInterval = 5000;
 
+	/**
+	 * True if the consumer is exclusive.
+	 */
+	private boolean exclusive;
+
 	public boolean isTransacted() {
 		return transacted;
 	}
@@ -159,4 +164,13 @@ public class RabbitConsumerProperties extends RabbitCommonProperties {
 	public void setRecoveryInterval(long recoveryInterval) {
 		this.recoveryInterval = recoveryInterval;
 	}
+
+	public boolean isExclusive() {
+		return this.exclusive;
+	}
+
+	public void setExclusive(boolean exclusive) {
+		this.exclusive = exclusive;
+	}
+
 }

--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisioner.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisioner.java
@@ -349,7 +349,7 @@ public class RabbitExchangeQueueProvisioner implements ProvisioningProvider<Exte
 				args.put("x-dead-letter-routing-key", dlRk);
 			}
 			additionalArgs(args, properties.getExpires(), properties.getMaxLength(), properties.getMaxLengthBytes(),
-					properties.getMaxPriority(), properties.getTtl());
+					properties.getMaxPriority(), properties.getTtl(), properties.isLazy());
 		}
 		else {
 			if (properties.getDlqDeadLetterExchange() != null) {
@@ -359,13 +359,14 @@ public class RabbitExchangeQueueProvisioner implements ProvisioningProvider<Exte
 				args.put("x-dead-letter-routing-key", properties.getDlqDeadLetterRoutingKey());
 			}
 			additionalArgs(args, properties.getDlqExpires(), properties.getDlqMaxLength(),
-					properties.getDlqMaxLengthBytes(), properties.getDlqMaxPriority(), properties.getDlqTtl());
+					properties.getDlqMaxLengthBytes(), properties.getDlqMaxPriority(), properties.getDlqTtl(),
+					properties.isDlqLazy());
 		}
 		return args;
 	}
 
 	private void additionalArgs(Map<String, Object> args, Integer expires, Integer maxLength, Integer maxLengthBytes,
-								Integer maxPriority, Integer ttl) {
+								Integer maxPriority, Integer ttl, boolean lazy) {
 		if (expires != null) {
 			args.put("x-expires", expires);
 		}
@@ -380,6 +381,9 @@ public class RabbitExchangeQueueProvisioner implements ProvisioningProvider<Exte
 		}
 		if (ttl != null) {
 			args.put("x-message-ttl", ttl);
+		}
+		if (lazy) {
+			args.put("x-queue-mode", "lazy");
 		}
 	}
 

--- a/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
@@ -148,6 +148,12 @@ dlqExpires::
   how long before an unused dead letter queue is deleted (ms)
 +
 Default: `no expiration`
+dlqLazy::
+  Declare the dead letter queue with the `x-queue-mode=lazy` argument.
+  See https://www.rabbitmq.com/lazy-queues.html[Lazy Queues].
+  Consider using a policy instead of this setting because using a policy allows changing the setting without deleting the queue.
++
+Default: `false`.
 dlqMaxLength::
   maximum number of messages in the dead letter queue
 +
@@ -181,6 +187,11 @@ exchangeType::
   The exchange type; `direct`, `fanout` or `topic` for non-partitioned destinations; `direct` or `topic` for partitioned destinations.
 +
 Default: `topic`.
+exclusive::
+  Create an exclusive consumer; concurrency should be 1 when this is `true`; often used when strict ordering is required but enabling a hot standby instance to take over after a failure.
+  See `recoveryInterval`, which controls how often a standby instance will attempt to consume.
++
+Default: `false`.
 expires::
   how long before an unused queue is deleted (ms)
 +
@@ -189,6 +200,12 @@ headerPatterns::
   Patterns for headers to be mapped from inbound messages.
 +
 Default: `['*']` (all headers).
+lazy::
+  Declare the queue with the `x-queue-mode=lazy` argument.
+  See https://www.rabbitmq.com/lazy-queues.html[Lazy Queues].
+  Consider using a policy instead of this setting because using a policy allows changing the setting without deleting the queue.
++
+Default: `false`.
 maxConcurrency::
   the maximum number of consumers
 +
@@ -327,6 +344,12 @@ dlqExpires::
   Only applies if `requiredGroups` are provided and then only to those groups.
 +
 Default: `no expiration`
+dlqLazy::
+  Declare the dead letter queue with the `x-queue-mode=lazy` argument.
+  See https://www.rabbitmq.com/lazy-queues.html[Lazy Queues].
+  Consider using a policy instead of this setting because using a policy allows changing the setting without deleting the queue.
+  Only applies if `requiredGroups` are provided and then only to those groups.
++
 dlqMaxLength::
   maximum number of messages in the dead letter queue
   Only applies if `requiredGroups` are provided and then only to those groups.
@@ -368,6 +391,13 @@ headerPatterns::
   Patterns for headers to be mapped to outbound messages.
 +
 Default: `['*']` (all headers).
+lazy::
+  Declare the queue with the `x-queue-mode=lazy` argument.
+  See https://www.rabbitmq.com/lazy-queues.html[Lazy Queues].
+  Consider using a policy instead of this setting because using a policy allows changing the setting without deleting the queue.
+  Only applies if `requiredGroups` are provided and then only to those groups.
++
+Default: `false`.
 maxLength::
   maximum number of messages in the queue
   Only applies if `requiredGroups` are provided and then only to those groups.

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -263,6 +263,7 @@ public class RabbitMessageChannelBinder
 		listenerContainer.setQueueNames(consumerDestination.getName());
 		listenerContainer.setAfterReceivePostProcessors(this.decompressingPostProcessor);
 		listenerContainer.setMessagePropertiesConverter(RabbitMessageChannelBinder.inboundMessagePropertiesConverter);
+		listenerContainer.setExclusive(properties.getExtension().isExclusive());
 		listenerContainer.afterPropertiesSet();
 
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(listenerContainer);


### PR DESCRIPTION
Resolves #58
Resolves #80

Add properties to support exclusive consumers and lazy queues.

__cherry-pick to 1.2.x__