### PR TITLE
Fix producer ConnectionFactory

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,14 @@
 package org.springframework.cloud.stream.binder.rabbit.config;
 
 import org.springframework.amqp.core.MessagePostProcessor;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean;
 import org.springframework.amqp.support.postprocessor.DelegatingDecompressingPostProcessor;
 import org.springframework.amqp.support.postprocessor.GZipPostProcessor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.amqp.RabbitProperties;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -28,23 +32,27 @@ import org.springframework.cloud.stream.binder.rabbit.RabbitMessageChannelBinder
 import org.springframework.cloud.stream.binder.rabbit.properties.RabbitBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.rabbit.properties.RabbitExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.rabbit.provisioning.RabbitExchangeQueueProvisioner;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.cloud.stream.config.codec.kryo.KryoCodecAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.codec.Codec;
 
-
 /**
  * Configuration class for RabbitMQ message channel binder.
  *
  * @author David Turanski
+ * @author Artem Bilan
  */
 
 @Configuration
 @Import({PropertyPlaceholderAutoConfiguration.class, KryoCodecAutoConfiguration.class})
 @EnableConfigurationProperties({RabbitBinderConfigurationProperties.class, RabbitExtendedBindingProperties.class})
 public class RabbitMessageChannelBinderConfiguration {
+
+	@Autowired
+	private ConfigurableApplicationContext applicationContext;
 
 	@Autowired
 	private Codec codec;
@@ -62,16 +70,130 @@ public class RabbitMessageChannelBinderConfiguration {
 	private RabbitExtendedBindingProperties rabbitExtendedBindingProperties;
 
 	@Bean
-	RabbitMessageChannelBinder rabbitMessageChannelBinder() {
+	RabbitMessageChannelBinder rabbitMessageChannelBinder(
+			@Qualifier("producerConnectionFactory") ObjectProvider<ConnectionFactory> producerConnectionFactory)
+			throws Exception {
+
 		RabbitMessageChannelBinder binder = new RabbitMessageChannelBinder(rabbitConnectionFactory, rabbitProperties,
 				provisioningProvider());
+		binder.setProducerConnectionFactory(obtainProducerConnectionFactory(producerConnectionFactory));
 		binder.setCodec(codec);
 		binder.setAdminAddresses(rabbitBinderConfigurationProperties.getAdminAddresses());
 		binder.setCompressingPostProcessor(gZipPostProcessor());
 		binder.setDecompressingPostProcessor(deCompressingPostProcessor());
-		binder.setNodes(rabbitBinderConfigurationProperties.getNodes());
-		binder.setExtendedBindingProperties(rabbitExtendedBindingProperties);
+		binder.setNodes(this.rabbitBinderConfigurationProperties.getNodes());
+		binder.setExtendedBindingProperties(this.rabbitExtendedBindingProperties);
 		return binder;
+	}
+
+	private ConnectionFactory obtainProducerConnectionFactory(
+			ObjectProvider<ConnectionFactory> connectionFactoryObjectProvider) throws Exception {
+
+		ConnectionFactory connectionFactory = connectionFactoryObjectProvider.getIfAvailable();
+
+		if (connectionFactory != null) {
+			return connectionFactory;
+		}
+		else {
+			return buildProducerConnectionFactory();
+		}
+	}
+
+	/**
+	 * @see org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration.RabbitConnectionFactoryCreator
+	 */
+	private CachingConnectionFactory buildProducerConnectionFactory() throws Exception {
+		com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory;
+		if (this.rabbitConnectionFactory instanceof CachingConnectionFactory) {
+			rabbitConnectionFactory =
+					((CachingConnectionFactory) this.rabbitConnectionFactory).getRabbitConnectionFactory();
+		}
+		else {
+			RabbitConnectionFactoryBean factory = new RabbitConnectionFactoryBean();
+			String host = this.rabbitProperties.determineHost();
+			if (host != null) {
+				factory.setHost(host);
+			}
+
+			factory.setPort(this.rabbitProperties.determinePort());
+
+
+			String username = this.rabbitProperties.determineUsername();
+			if (username != null) {
+				factory.setUsername(username);
+			}
+
+			String password = this.rabbitProperties.determinePassword();
+			if (password != null) {
+				factory.setPassword(password);
+			}
+
+			String virtualHost = this.rabbitProperties.determineVirtualHost();
+			if (virtualHost != null) {
+				factory.setVirtualHost(virtualHost);
+			}
+
+			Integer requestedHeartbeat = this.rabbitProperties.getRequestedHeartbeat();
+			if (requestedHeartbeat != null) {
+				factory.setRequestedHeartbeat(requestedHeartbeat);
+			}
+			RabbitProperties.Ssl ssl = this.rabbitProperties.getSsl();
+
+			if (ssl.isEnabled()) {
+				factory.setUseSSL(true);
+				if (ssl.getAlgorithm() != null) {
+					factory.setSslAlgorithm(ssl.getAlgorithm());
+				}
+				factory.setKeyStore(ssl.getKeyStore());
+				factory.setKeyStorePassphrase(ssl.getKeyStorePassword());
+				factory.setTrustStore(ssl.getTrustStore());
+				factory.setTrustStorePassphrase(ssl.getTrustStorePassword());
+			}
+
+			Integer connectionTimeout = this.rabbitProperties.getConnectionTimeout();
+			if (connectionTimeout != null) {
+				factory.setConnectionTimeout(connectionTimeout);
+			}
+
+			factory.afterPropertiesSet();
+
+			rabbitConnectionFactory = factory.getObject();
+		}
+
+		CachingConnectionFactory connectionFactory = new CachingConnectionFactory(rabbitConnectionFactory);
+		connectionFactory.setAddresses(this.rabbitProperties.determineAddresses());
+		connectionFactory.setPublisherConfirms(this.rabbitProperties.isPublisherConfirms());
+		connectionFactory.setPublisherReturns(this.rabbitProperties.isPublisherReturns());
+
+		RabbitProperties.Cache.Channel channel = this.rabbitProperties.getCache().getChannel();
+		RabbitProperties.Cache.Connection connection = this.rabbitProperties.getCache().getConnection();
+
+		Integer channelSize = channel.getSize();
+		if (channelSize != null) {
+			connectionFactory.setChannelCacheSize(channelSize);
+		}
+
+		Long channelCheckoutTimeout = channel.getCheckoutTimeout();
+		if (channelCheckoutTimeout != null) {
+			connectionFactory.setChannelCheckoutTimeout(
+					channelCheckoutTimeout);
+		}
+
+		CachingConnectionFactory.CacheMode connectionMode = connection.getMode();
+		if (connectionMode != null) {
+			connectionFactory.setCacheMode(connectionMode);
+		}
+
+		Integer connectionSize = connection.getSize();
+		if (connectionSize != null) {
+			connectionFactory.setConnectionCacheSize(connectionSize);
+		}
+
+		connectionFactory.setApplicationContext(this.applicationContext);
+		this.applicationContext.addApplicationListener(connectionFactory);
+		connectionFactory.afterPropertiesSet();
+
+		return connectionFactory;
 	}
 
 	@Bean
@@ -82,13 +204,13 @@ public class RabbitMessageChannelBinderConfiguration {
 	@Bean
 	MessagePostProcessor gZipPostProcessor() {
 		GZipPostProcessor gZipPostProcessor = new GZipPostProcessor();
-		gZipPostProcessor.setLevel(rabbitBinderConfigurationProperties.getCompressionLevel());
+		gZipPostProcessor.setLevel(this.rabbitBinderConfigurationProperties.getCompressionLevel());
 		return gZipPostProcessor;
 	}
 
 	@Bean
 	RabbitExchangeQueueProvisioner provisioningProvider() {
-		return new RabbitExchangeQueueProvisioner(rabbitConnectionFactory);
+		return new RabbitExchangeQueueProvisioner(this.rabbitConnectionFactory);
 	}
-}
 
+}

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -16,6 +16,13 @@
 
 package org.springframework.cloud.stream.binder.rabbit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -93,13 +100,6 @@ import org.springframework.util.ReflectionUtils;
 
 import com.rabbitmq.http.client.domain.QueueInfo;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 /**
  * @author Mark Fisher
  * @author Gary Russell
@@ -164,17 +164,9 @@ public class RabbitBinderTests extends
 				TestUtils.getPropertyValue(producerBinding, "lifecycle.amqpTemplate.connectionFactory",
 						ConnectionFactory.class);
 
-		ConnectionFactory consumerConnectionFactory =
-				TestUtils.getPropertyValue(consumerBinding, "lifecycle.messageListenerContainer.connectionFactory",
-						ConnectionFactory.class);
-
-		assertThat(producerConnectionFactory).isNotSameAs(consumerConnectionFactory);
-
-		assertThat(producerConnectionFactory.createConnection())
-				.isNotEqualTo(consumerConnectionFactory.createConnection());
-
 		Message<?> message = MessageBuilder.withPayload("bad").setHeader(MessageHeaders.CONTENT_TYPE, "foo/bar")
 				.build();
+
 		final CountDownLatch latch = new CountDownLatch(3);
 		moduleInputChannel.subscribe(new MessageHandler() {
 

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestBinder.java
@@ -64,6 +64,7 @@ public class RabbitTestBinder extends AbstractTestBinder<RabbitMessageChannelBin
 	public RabbitTestBinder(ConnectionFactory connectionFactory, RabbitMessageChannelBinder binder) {
 		this.applicationContext = new AnnotationConfigApplicationContext(Config.class);
 		binder.setApplicationContext(this.applicationContext);
+		binder.setProducerConnectionFactory(connectionFactory);
 		binder.setCodec(new PojoCodec());
 		this.setBinder(binder);
 		this.rabbitAdmin = new RabbitAdmin(connectionFactory);

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/integration/RabbitBinderModuleTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/integration/RabbitBinderModuleTests.java
@@ -16,6 +16,12 @@
 
 package org.springframework.cloud.stream.binder.rabbit.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +42,8 @@ import org.springframework.boot.actuate.health.CompositeHealthIndicator;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.Cloud;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.binder.BinderFactory;
@@ -56,11 +64,10 @@ import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  * @author Marius Bogoevici
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class RabbitBinderModuleTests {
 
@@ -69,7 +76,7 @@ public class RabbitBinderModuleTests {
 
 	private ConfigurableApplicationContext context;
 
-	public static final ConnectionFactory MOCK_CONNECTION_FACTORY = Mockito.mock(ConnectionFactory.class,
+	public static final ConnectionFactory MOCK_CONNECTION_FACTORY = mock(ConnectionFactory.class,
 			Mockito.RETURNS_MOCKS);
 
 	@After
@@ -97,6 +104,11 @@ public class RabbitBinderModuleTests {
 		assertThat(binderConnectionFactory).isInstanceOf(CachingConnectionFactory.class);
 		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
 		assertThat(binderConnectionFactory).isSameAs(connectionFactory);
+
+		ConnectionFactory producerConnectionFactory = (ConnectionFactory) binderFieldAccessor
+				.getPropertyValue("producerConnectionFactory");
+		assertThat(producerConnectionFactory).isNotSameAs(connectionFactory);
+
 		CompositeHealthIndicator bindersHealthIndicator = context.getBean("bindersHealthIndicator",
 				CompositeHealthIndicator.class);
 		DirectFieldAccessor directFieldAccessor = new DirectFieldAccessor(bindersHealthIndicator);
@@ -188,10 +200,7 @@ public class RabbitBinderModuleTests {
 		context = SpringApplication.run(SimpleProcessor.class, params.toArray(new String[params.size()]));
 		BinderFactory binderFactory = context.getBean(BinderFactory.class);
 		@SuppressWarnings("unchecked")
-		Binder<MessageChannel, ExtendedConsumerProperties<RabbitConsumerProperties>,
-								ExtendedProducerProperties<RabbitProducerProperties>> binder =
-			(Binder<MessageChannel, ExtendedConsumerProperties<RabbitConsumerProperties>,
-					ExtendedProducerProperties<RabbitProducerProperties>>) binderFactory
+		Binder<MessageChannel, ExtendedConsumerProperties<RabbitConsumerProperties>, ExtendedProducerProperties<RabbitProducerProperties>> binder = (Binder<MessageChannel, ExtendedConsumerProperties<RabbitConsumerProperties>, ExtendedProducerProperties<RabbitProducerProperties>>) binderFactory
 				.getBinder(null, MessageChannel.class);
 		assertThat(binder).isInstanceOf(RabbitMessageChannelBinder.class);
 		DirectFieldAccessor binderFieldAccessor = new DirectFieldAccessor(binder);
@@ -224,6 +233,31 @@ public class RabbitBinderModuleTests {
 		context.close();
 	}
 
+	@Test
+	public void testCloudProfile() {
+		this.context = new SpringApplicationBuilder(SimpleProcessor.class, MockCloudConfiguration.class)
+				.profiles("cloud")
+				.run("--server.port=0");
+		BinderFactory binderFactory = this.context.getBean(BinderFactory.class);
+		Binder<?, ?, ?> binder = binderFactory.getBinder(null, MessageChannel.class);
+		assertThat(binder).isInstanceOf(RabbitMessageChannelBinder.class);
+		DirectFieldAccessor binderFieldAccessor = new DirectFieldAccessor(binder);
+		ConnectionFactory binderConnectionFactory = (ConnectionFactory) binderFieldAccessor
+				.getPropertyValue("connectionFactory");
+		ConnectionFactory connectionFactory = this.context.getBean(ConnectionFactory.class);
+		assertThat(binderConnectionFactory).isNotSameAs(connectionFactory);
+
+		ConnectionFactory producerConnectionFactory = (ConnectionFactory) binderFieldAccessor
+				.getPropertyValue("producerConnectionFactory");
+		assertThat(producerConnectionFactory).isNotSameAs(connectionFactory);
+
+		assertThat(binderConnectionFactory).isNotSameAs(connectionFactory);
+
+		Cloud cloud = this.context.getBean(Cloud.class);
+
+		verify(cloud, times(2)).getSingletonServiceConnector(ConnectionFactory.class, null);
+	}
+
 	@EnableBinding(Processor.class)
 	@SpringBootApplication
 	public static class SimpleProcessor {
@@ -235,6 +269,20 @@ public class RabbitBinderModuleTests {
 		@Bean
 		public ConnectionFactory connectionFactory() {
 			return MOCK_CONNECTION_FACTORY;
+		}
+
+	}
+
+	public static class MockCloudConfiguration {
+
+		@Bean
+		public Cloud cloud() {
+			Cloud cloud = mock(Cloud.class);
+
+			given(cloud.getSingletonServiceConnector(ConnectionFactory.class, null))
+					.willReturn(mock(ConnectionFactory.class), mock(ConnectionFactory.class));
+
+			return cloud;
 		}
 
 	}


### PR DESCRIPTION
The `RabbitMessageChannelBinder` creates an internal distinct
`ConnectionFactory` instance based on the `RabbitProperties` for the
non-transactional producers to avoid dead locks when connection
is blocked.
In case of Cloud Connectors the `ConnectionFactory` bean is overridden,
but not `RabbitProperties`.
Therefore the original `ConnectionFactory` for consumers is good,
cloud-based, but for producers it is still based on the `RabbitProperties`
from Spring Boot, in most cases with default options.

* Add one more `producerConnectionFactory` `@Bean` to the
`CloudConnectors` configuration to obtain a distinct `ConnectionFactory`
instance from the cloud provider
* When we ara not in the cloud profile, create a fresh `ConnectionFactory`
based on the `RabbitProperties`
* Inject the extra `producerConnectionFactory` instance into the
`RabbitMessageChannelBinder` instead of the internal non-stable solution

**Cherry-pick to 1.3.x**

Conflicts:
	spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
	spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
	spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestBinder.java
	spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/integration/RabbitBinderModuleTests.java