### PR TITLE
Add ServiceConnectorConfig injection support

### DIFF
--- a/spring-cloud-stream-binder-rabbit/pom.xml
+++ b/spring-cloud-stream-binder-rabbit/pom.xml
@@ -39,6 +39,12 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-spring-service-connector</artifactId>
+			<optional>true</optional>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-amqp</artifactId>
 		</dependency>

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.Cloud;
 import org.springframework.cloud.CloudFactory;
-import org.springframework.cloud.service.ServiceConnectorConfig;
+import org.springframework.cloud.service.messaging.RabbitConnectionFactoryConfig;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -52,7 +52,8 @@ import org.springframework.context.annotation.Profile;
  */
 @Configuration
 @ConditionalOnMissingBean(Binder.class)
-@Import({RabbitMessageChannelBinderConfiguration.class, RabbitServiceAutoConfiguration.RabbitHealthIndicatorConfiguration.class})
+@Import({ RabbitMessageChannelBinderConfiguration.class,
+		RabbitServiceAutoConfiguration.RabbitHealthIndicatorConfiguration.class })
 public class RabbitServiceAutoConfiguration {
 
 	/**
@@ -63,8 +64,8 @@ public class RabbitServiceAutoConfiguration {
 	protected static class CloudProfile {
 
 		/**
-		 * Configuration to be used when the cloud profile is set, and Cloud Connectors
-		 * are found on the classpath.
+		 * Configuration to be used when the cloud profile is set, and Cloud Connectors are found
+		 * on the classpath.
 		 */
 		@Configuration
 		@ConditionalOnClass(Cloud.class)
@@ -77,12 +78,12 @@ public class RabbitServiceAutoConfiguration {
 			}
 
 			/**
-			 * Active only if {@code spring.cloud.stream.overrideCloudConnectors} is not
-			 * set to {@code true}.
+			 * Active only if {@code spring.cloud.stream.overrideCloudConnectors} is not set to
+			 * {@code true}.
 			 */
 			@Configuration
-			@ConditionalOnProperty(value = "spring.cloud.stream.overrideCloudConnectors",
-					havingValue = "false", matchIfMissing = true)
+			@ConditionalOnProperty(value = "spring.cloud.stream.overrideCloudConnectors", havingValue = "false",
+					matchIfMissing = true)
 			// Required to parse Rabbit properties which are passed to the binder for
 			// clustering. We need to enable it here explicitly as the default Rabbit
 			// configuration is not triggered.
@@ -93,33 +94,32 @@ public class RabbitServiceAutoConfiguration {
 				 * Creates a {@link ConnectionFactory} using the singleton service connector.
 				 * @param cloud {@link Cloud} instance to be used for accessing services.
 				 * @param connectorConfigObjectProvider the {@link ObjectProvider} for the
-				 * {@link ServiceConnectorConfig}; in this case the expectation is about
-				 * {@code org.springframework.cloud.service.messaging.RabbitConnectionFactoryConfig}.
+				 * {@link RabbitConnectionFactoryConfig}.
 				 * @return the {@link ConnectionFactory} used by the binder.
 				 */
 				@Bean
 				@Primary
 				ConnectionFactory rabbitConnectionFactory(Cloud cloud,
-						ObjectProvider<ServiceConnectorConfig> connectorConfigObjectProvider) {
+						ObjectProvider<RabbitConnectionFactoryConfig> connectorConfigObjectProvider) {
 
 					return cloud.getSingletonServiceConnector(ConnectionFactory.class,
-							connectorConfigObjectProvider.getIfAvailable());
+							connectorConfigObjectProvider.getIfUnique());
 				}
 
 				/**
-				 * Creates a {@link ConnectionFactory} for non-transactional producers
-				 * using the singleton service connector.
+				 * Creates a {@link ConnectionFactory} for non-transactional producers using the singleton
+				 * service connector.
 				 * @param cloud {@link Cloud} instance to be used for accessing services.
 				 * @param connectorConfigObjectProvider the {@link ObjectProvider} for the
-				 * {@link ServiceConnectorConfig}; in this case the expectation is about
-				 * {@code org.springframework.cloud.service.messaging.RabbitConnectionFactoryConfig}.
-				 * @return the {@link ConnectionFactory} used by the binder for non-transactional producers.
+				 * {@link RabbitConnectionFactoryConfig}.
+				 * @return the {@link ConnectionFactory} used by the binder for non-transactional
+				 * producers.
 				 */
 				@Bean
 				ConnectionFactory producerConnectionFactory(Cloud cloud,
-						ObjectProvider<ServiceConnectorConfig> connectorConfigObjectProvider) {
+						ObjectProvider<RabbitConnectionFactoryConfig> connectorConfigObjectProvider) {
 					return cloud.getSingletonServiceConnector(ConnectionFactory.class,
-							connectorConfigObjectProvider.getIfAvailable());
+							connectorConfigObjectProvider.getIfUnique());
 				}
 
 				@Bean
@@ -130,9 +130,8 @@ public class RabbitServiceAutoConfiguration {
 			}
 
 			/**
-			 * Configuration to be used if
-			 * {@code spring.cloud.stream.overrideCloudConnectors} is set to {@code true}.
-			 * Defers to Spring Boot auto-configuration.
+			 * Configuration to be used if {@code spring.cloud.stream.overrideCloudConnectors} is set
+			 * to {@code true}. Defers to Spring Boot auto-configuration.
 			 */
 			@Configuration
 			@ConditionalOnProperty("spring.cloud.stream.overrideCloudConnectors")

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.stream.binder.rabbit.config;
 
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.amqp.RabbitHealthIndicator;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
@@ -29,6 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.Cloud;
 import org.springframework.cloud.CloudFactory;
+import org.springframework.cloud.service.ServiceConnectorConfig;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -88,27 +90,36 @@ public class RabbitServiceAutoConfiguration {
 			protected static class UseCloudConnectors {
 
 				/**
-				 * Creates a {@link ConnectionFactory} using the singleton service
-				 * connector.
-				 *
+				 * Creates a {@link ConnectionFactory} using the singleton service connector.
 				 * @param cloud {@link Cloud} instance to be used for accessing services.
+				 * @param connectorConfigObjectProvider the {@link ObjectProvider} for the
+				 * {@link ServiceConnectorConfig}; in this case the expectation is about
+				 * {@code org.springframework.cloud.service.messaging.RabbitConnectionFactoryConfig}.
 				 * @return the {@link ConnectionFactory} used by the binder.
 				 */
 				@Bean
 				@Primary
-				ConnectionFactory rabbitConnectionFactory(Cloud cloud) {
-					return cloud.getSingletonServiceConnector(ConnectionFactory.class, null);
+				ConnectionFactory rabbitConnectionFactory(Cloud cloud,
+						ObjectProvider<ServiceConnectorConfig> connectorConfigObjectProvider) {
+
+					return cloud.getSingletonServiceConnector(ConnectionFactory.class,
+							connectorConfigObjectProvider.getIfAvailable());
 				}
 
 				/**
 				 * Creates a {@link ConnectionFactory} for non-transactional producers
 				 * using the singleton service connector.
 				 * @param cloud {@link Cloud} instance to be used for accessing services.
+				 * @param connectorConfigObjectProvider the {@link ObjectProvider} for the
+				 * {@link ServiceConnectorConfig}; in this case the expectation is about
+				 * {@code org.springframework.cloud.service.messaging.RabbitConnectionFactoryConfig}.
 				 * @return the {@link ConnectionFactory} used by the binder for non-transactional producers.
 				 */
 				@Bean
-				ConnectionFactory producerConnectionFactory(Cloud cloud) {
-					return cloud.getSingletonServiceConnector(ConnectionFactory.class, null);
+				ConnectionFactory producerConnectionFactory(Cloud cloud,
+						ObjectProvider<ServiceConnectorConfig> connectorConfigObjectProvider) {
+					return cloud.getSingletonServiceConnector(ConnectionFactory.class,
+							connectorConfigObjectProvider.getIfAvailable());
 				}
 
 				@Bean

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/integration/RabbitBinderModuleTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/integration/RabbitBinderModuleTests.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.stream.binder.rabbit.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
@@ -262,7 +261,7 @@ public class RabbitBinderModuleTests {
 
 		Cloud cloud = this.context.getBean(Cloud.class);
 
-		verify(cloud, times(2)).getSingletonServiceConnector(ConnectionFactory.class, null);
+		verify(cloud).getSingletonServiceConnector(ConnectionFactory.class, null);
 	}
 
 	@EnableBinding(Processor.class)
@@ -286,7 +285,7 @@ public class RabbitBinderModuleTests {
 		public Cloud cloud() {
 			Cloud cloud = mock(Cloud.class);
 
-			willReturn(mock(ConnectionFactory.class), mock(ConnectionFactory.class))
+			willReturn(new CachingConnectionFactory())
 							.given(cloud)
 							.getSingletonServiceConnector(ConnectionFactory.class, null);
 


### PR DESCRIPTION
The SC-Connectors `ServiceConnector` can be customized via
`ServiceConnectorConfig`.

* Allow end-user to specify such a bean and support its injection in the
`rabbitConnectionFactory` and `producerConnectionFactory` bean definitions

**Cherry-pick to 1.3.x**

Resolves spring-cloud/spring-cloud-stream-binder-rabbit#118