### PR TITLE
Fix CCF addresses population in Cloud profile

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
+import org.springframework.util.StringUtils;
 
 /**
  * Bind to services, either locally or in a cloud environment.
@@ -167,7 +168,10 @@ public class RabbitServiceAutoConfiguration {
 	static void configureCachingConnectionFactory(CachingConnectionFactory connectionFactory,
 			ConfigurableApplicationContext applicationContext, RabbitProperties rabbitProperties) throws Exception {
 
-		connectionFactory.setAddresses(rabbitProperties.determineAddresses());
+		if (StringUtils.hasText(rabbitProperties.getAddresses())) {
+			connectionFactory.setAddresses(rabbitProperties.determineAddresses());
+		}
+
 		connectionFactory.setPublisherConfirms(rabbitProperties.isPublisherConfirms());
 		connectionFactory.setPublisherReturns(rabbitProperties.isPublisherReturns());
 		if (rabbitProperties.getCache().getChannel().getSize() != null) {

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/integration/RabbitBinderModuleTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/integration/RabbitBinderModuleTests.java
@@ -251,13 +251,19 @@ public class RabbitBinderModuleTests {
 		ConnectionFactory binderConnectionFactory = (ConnectionFactory) binderFieldAccessor
 				.getPropertyValue("connectionFactory");
 		ConnectionFactory connectionFactory = this.context.getBean(ConnectionFactory.class);
+
 		assertThat(binderConnectionFactory).isNotSameAs(connectionFactory);
 
 		ConnectionFactory producerConnectionFactory = (ConnectionFactory) binderFieldAccessor
 				.getPropertyValue("producerConnectionFactory");
+
 		assertThat(producerConnectionFactory).isNotSameAs(connectionFactory);
 
-		assertThat(binderConnectionFactory).isNotSameAs(connectionFactory);
+		assertThat(binderConnectionFactory).isNotSameAs(producerConnectionFactory);
+
+		assertThat(TestUtils.getPropertyValue(connectionFactory, "addresses")).isNotNull();
+		assertThat(TestUtils.getPropertyValue(binderConnectionFactory, "addresses")).isNull();
+		assertThat(TestUtils.getPropertyValue(producerConnectionFactory, "addresses")).isNull();
 
 		Cloud cloud = this.context.getBean(Cloud.class);
 


### PR DESCRIPTION
The Spring Boot's `RabbitProperties` populates the `host:port`
(default values) to the addresses property in the `determineAddresses()`.
This way we override provided by Cloud Connectors `host:port`

* Do not populated `addresses` to the CCF from the `RabbitProperties`
if the real `addresses` is null.
Only explicit `spring.rabbitmq.addresses` application property will have
effect

**Cherry-pick to 1.3.x**
  
Resolves spring-cloud/spring-cloud-stream-binder-rabbit#120