### PR TITLE
GH-128: Fix connection factory destruction [1.3.x]

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +118,8 @@ public class RabbitMessageChannelBinder
 
 	private final RabbitProperties rabbitProperties;
 
+	private boolean destroyConnectionFactory;
+
 	private ConnectionFactory connectionFactory;
 
 	private ConnectionFactory producerConnectionFactory;
@@ -201,13 +203,16 @@ public class RabbitMessageChannelBinder
 					this.rabbitProperties.getSsl().getTrustStore(),
 					this.rabbitProperties.getSsl().getKeyStorePassword(),
 					this.rabbitProperties.getSsl().getTrustStorePassword());
+			this.destroyConnectionFactory = true;
 		}
 	}
 
 	@Override
 	public void destroy() throws Exception {
 		if (this.connectionFactory instanceof DisposableBean) {
-			((DisposableBean) this.connectionFactory).destroy();
+			if (this.destroyConnectionFactory) {
+				((DisposableBean) this.connectionFactory).destroy();
+			}
 			((DisposableBean) this.producerConnectionFactory).destroy();
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/128

The binder incorrectly shuts down the connection factory `@Bean`, before the bindings
are stopped, preventing the container waiting for tasks to complete.

Code was added to destroy the CF in the case where we create one locally, which is
correct, but we should not destroy the CF managed by Spring.

Also see https://jira.spring.io/browse/AMQP-800

__cherry-pick to master__