### PR TITLE
GH-130: Remove producerConnectionFactory

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,8 @@
 
 package org.springframework.cloud.stream.binder.rabbit.config;
 
-import java.time.Duration;
-
 import org.springframework.amqp.core.MessagePostProcessor;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean;
 import org.springframework.amqp.support.postprocessor.DelegatingDecompressingPostProcessor;
 import org.springframework.amqp.support.postprocessor.GZipPostProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +40,7 @@ import org.springframework.context.annotation.Import;
  * @author Vinicius Carvalho
  * @author Artem Bilan
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 @Configuration
 @Import({ PropertyPlaceholderAutoConfiguration.class })
@@ -69,73 +66,12 @@ public class RabbitMessageChannelBinderConfiguration {
 	RabbitMessageChannelBinder rabbitMessageChannelBinder() throws Exception {
 		RabbitMessageChannelBinder binder = new RabbitMessageChannelBinder(this.rabbitConnectionFactory,
 				this.rabbitProperties, provisioningProvider());
-		binder.setProducerConnectionFactory(buildProducerConnectionFactory());
 		binder.setAdminAddresses(this.rabbitBinderConfigurationProperties.getAdminAddresses());
 		binder.setCompressingPostProcessor(gZipPostProcessor());
 		binder.setDecompressingPostProcessor(deCompressingPostProcessor());
 		binder.setNodes(this.rabbitBinderConfigurationProperties.getNodes());
 		binder.setExtendedBindingProperties(this.rabbitExtendedBindingProperties);
 		return binder;
-	}
-
-	/**
-	 * @see org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration.RabbitConnectionFactoryCreator
-	 */
-	private CachingConnectionFactory buildProducerConnectionFactory() throws Exception {
-		com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory;
-		if (this.rabbitConnectionFactory instanceof CachingConnectionFactory) {
-			rabbitConnectionFactory = ((CachingConnectionFactory) this.rabbitConnectionFactory)
-					.getRabbitConnectionFactory();
-		}
-		else {
-			RabbitConnectionFactoryBean factory = new RabbitConnectionFactoryBean();
-			String host = this.rabbitProperties.determineHost();
-			if (host != null) {
-				factory.setHost(host);
-			}
-			factory.setPort(this.rabbitProperties.determinePort());
-			String user = this.rabbitProperties.determineUsername();
-			if (user != null) {
-				factory.setUsername(user);
-			}
-			String password = this.rabbitProperties.determinePassword();
-			if (password != null) {
-				factory.setPassword(password);
-			}
-			String vHost = this.rabbitProperties.determineVirtualHost();
-			if (vHost != null) {
-				factory.setVirtualHost(vHost);
-			}
-			Duration requestedHeartbeatDuration = this.rabbitProperties.getRequestedHeartbeat();
-			if (requestedHeartbeatDuration != null) {
-				factory.setRequestedHeartbeat((int) requestedHeartbeatDuration.getSeconds());
-			}
-			RabbitProperties.Ssl ssl = this.rabbitProperties.getSsl();
-			if (ssl.isEnabled()) {
-				factory.setUseSSL(true);
-				if (ssl.getAlgorithm() != null) {
-					factory.setSslAlgorithm(ssl.getAlgorithm());
-				}
-				factory.setKeyStore(ssl.getKeyStore());
-				factory.setKeyStorePassphrase(ssl.getKeyStorePassword());
-				factory.setTrustStore(ssl.getTrustStore());
-				factory.setTrustStorePassphrase(ssl.getTrustStorePassword());
-			}
-			Duration connectionTimeoutDuration = this.rabbitProperties.getConnectionTimeout();
-			if (connectionTimeoutDuration != null) {
-				factory.setConnectionTimeout((int) connectionTimeoutDuration.getSeconds());
-			}
-			factory.afterPropertiesSet();
-
-			rabbitConnectionFactory = factory.getObject();
-		}
-
-		CachingConnectionFactory connectionFactory = new CachingConnectionFactory(rabbitConnectionFactory);
-
-		RabbitServiceAutoConfiguration.configureCachingConnectionFactory(connectionFactory, this.applicationContext,
-				this.rabbitProperties);
-
-		return connectionFactory;
 	}
 
 	@Bean

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import org.springframework.util.StringUtils;
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
  * @author Artem Bilan
+ * @author Gary Russell
  */
 @Configuration
 @ConditionalOnMissingBean(Binder.class)
@@ -186,7 +187,7 @@ public class RabbitServiceAutoConfiguration {
 		}
 		if (rabbitProperties.getCache().getChannel().getCheckoutTimeout() != null) {
 			connectionFactory.setChannelCheckoutTimeout(
-					rabbitProperties.getCache().getChannel().getCheckoutTimeout());
+					rabbitProperties.getCache().getChannel().getCheckoutTimeout().toMillis());
 		}
 		connectionFactory.setApplicationContext(applicationContext);
 		applicationContext.addApplicationListener(connectionFactory);

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestBinder.java
@@ -67,7 +67,6 @@ public class RabbitTestBinder extends
 	public RabbitTestBinder(ConnectionFactory connectionFactory, RabbitMessageChannelBinder binder) {
 		this.applicationContext = new AnnotationConfigApplicationContext(Config.class);
 		binder.setApplicationContext(this.applicationContext);
-		binder.setProducerConnectionFactory(connectionFactory);
 		this.setPollableConsumerBinder(binder);
 		this.rabbitAdmin = new RabbitAdmin(connectionFactory);
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/130

Remove the creation of a separate `producerConnectionFactory`; use the `RabbitTemplate`'s
built-in 'usePublisherConnection` instead.

Fix `Duration` retry properties.