### PR TITLE
GH-134: Propagate the event publisher to container

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -105,7 +105,7 @@ public class RabbitMessageChannelBinder
 		extends AbstractMessageChannelBinder<ExtendedConsumerProperties<RabbitConsumerProperties>,
 		ExtendedProducerProperties<RabbitProducerProperties>, RabbitExchangeQueueProvisioner>
 		implements ExtendedPropertiesBinder<MessageChannel, RabbitConsumerProperties, RabbitProducerProperties>,
-		DisposableBean {
+			DisposableBean {
 
 	private static final AmqpMessageHeaderErrorMessageStrategy errorMessageStrategy =
 			new AmqpMessageHeaderErrorMessageStrategy();
@@ -373,6 +373,12 @@ public class RabbitMessageChannelBinder
 		if (properties.getExtension().getFailedDeclarationRetryInterval() != null) {
 			listenerContainer.setFailedDeclarationRetryInterval(
 					properties.getExtension().getFailedDeclarationRetryInterval());
+		}
+		if (getApplicationEventPublisher() != null) {
+			listenerContainer.setApplicationEventPublisher(getApplicationEventPublisher());
+		}
+		else if (getApplicationContext() != null) {
+			listenerContainer.setApplicationEventPublisher(getApplicationContext());
 		}
 		listenerContainer.afterPropertiesSet();
 


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/134

Requires https://github.com/spring-cloud/spring-cloud-stream/pull/1282