### PR TITLE
GH-139: Advanced listener container configuration

### DIFF
--- a/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
@@ -301,6 +301,12 @@ The number of deliveries between acks.
 +
 Default: `1`.
 
+=== Advanced Listener Container Configuration
+
+To set listener container properties that are not exposed as binder or binding properties, add a single bean of type `ListenerContainerCustomizer` to the application context.
+The binder and binding properties will be set and then the customizer will be called.
+The customizer (`configure()` method) is provided with the queue name as well as the consumer group as arguments.
+
 === Rabbit Producer Properties
 
 The following properties are available for Rabbit producers only and

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -52,6 +52,7 @@ import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.ExtendedPropertiesBinder;
 import org.springframework.cloud.stream.binder.HeaderMode;
+import org.springframework.cloud.stream.binder.rabbit.config.ListenerContainerCustomizer;
 import org.springframework.cloud.stream.binder.rabbit.properties.RabbitCommonProperties;
 import org.springframework.cloud.stream.binder.rabbit.properties.RabbitConsumerProperties;
 import org.springframework.cloud.stream.binder.rabbit.properties.RabbitExtendedBindingProperties;
@@ -125,6 +126,8 @@ public class RabbitMessageChannelBinder
 
 	private final RabbitProperties rabbitProperties;
 
+	private final ListenerContainerCustomizer containerCustomizer;
+
 	private boolean destroyConnectionFactory;
 
 	private ConnectionFactory connectionFactory;
@@ -143,11 +146,18 @@ public class RabbitMessageChannelBinder
 
 	public RabbitMessageChannelBinder(ConnectionFactory connectionFactory, RabbitProperties rabbitProperties,
 			RabbitExchangeQueueProvisioner provisioningProvider) {
+		this(connectionFactory, rabbitProperties, provisioningProvider, null);
+	}
+
+	public RabbitMessageChannelBinder(ConnectionFactory connectionFactory, RabbitProperties rabbitProperties,
+			RabbitExchangeQueueProvisioner provisioningProvider,
+			ListenerContainerCustomizer containerCustomizer) {
 		super(new String[0], provisioningProvider);
 		Assert.notNull(connectionFactory, "connectionFactory must not be null");
 		Assert.notNull(rabbitProperties, "rabbitProperties must not be null");
 		this.connectionFactory = connectionFactory;
 		this.rabbitProperties = rabbitProperties;
+		this.containerCustomizer = containerCustomizer == null ? (c, q, g) -> { } : containerCustomizer;
 	}
 
 	/**
@@ -380,6 +390,7 @@ public class RabbitMessageChannelBinder
 		else if (getApplicationContext() != null) {
 			listenerContainer.setApplicationEventPublisher(getApplicationContext());
 		}
+		this.containerCustomizer.configure(listenerContainer, consumerDestination.getName(), group);
 		listenerContainer.afterPropertiesSet();
 
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(listenerContainer);

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/ListenerContainerCustomizer.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/ListenerContainerCustomizer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.rabbit.config;
+
+import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
+
+/**
+ * If a single bean of this type is in the application context, listener
+ * containers created by the binder can be further customized after all
+ * the properties are set. For example, to configure less-common
+ * properties.
+ *
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+@FunctionalInterface
+public interface ListenerContainerCustomizer {
+
+	/**
+	 * Configure the container that is being created for the supplied queue name and
+	 * consumer group.
+	 * @param container the container.
+	 * @param queueName the destination name.
+	 * @param group the consumer group.
+	 */
+	void configure(AbstractMessageListenerContainer container, String queueName, String group);
+
+}

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
@@ -34,7 +34,6 @@ import org.springframework.cloud.stream.binder.rabbit.RabbitMessageChannelBinder
 import org.springframework.cloud.stream.binder.rabbit.properties.RabbitBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.rabbit.properties.RabbitExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.rabbit.provisioning.RabbitExchangeQueueProvisioner;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -54,9 +53,6 @@ import org.springframework.context.annotation.Import;
 public class RabbitMessageChannelBinderConfiguration {
 
 	@Autowired
-	private ConfigurableApplicationContext applicationContext;
-
-	@Autowired
 	private ConnectionFactory rabbitConnectionFactory;
 
 	@Autowired
@@ -68,10 +64,13 @@ public class RabbitMessageChannelBinderConfiguration {
 	@Autowired
 	private RabbitExtendedBindingProperties rabbitExtendedBindingProperties;
 
+	@Autowired(required = false)
+	private ListenerContainerCustomizer containerCustomizer;
+
 	@Bean
 	RabbitMessageChannelBinder rabbitMessageChannelBinder() throws Exception {
 		RabbitMessageChannelBinder binder = new RabbitMessageChannelBinder(this.rabbitConnectionFactory,
-				this.rabbitProperties, provisioningProvider());
+				this.rabbitProperties, provisioningProvider(), this.containerCustomizer);
 		binder.setAdminAddresses(this.rabbitBinderConfigurationProperties.getAdminAddresses());
 		binder.setCompressingPostProcessor(gZipPostProcessor());
 		binder.setDecompressingPostProcessor(deCompressingPostProcessor());


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/139

Allow configuration of listener container properties that are not exposed as binding
or binder properties.