### PR TITLE
GH-149: Support multiplexed consumers

### DIFF
--- a/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
@@ -63,6 +63,8 @@ You can exclude the class by using the `@SpringBootApplication` annotation.
 
 Starting with version 2.0, the `RabbitMessageChannelBinder` sets the `RabbitTemplate.userPublisherConnection` property to `true` so that the non-transactional producers avoid deadlocks on consumers, which can happen if cached connections are blocked because of a https://www.rabbitmq.com/memory.html[memory alarm] on the broker.
 
+NOTE: Currently, a `multiplex` consumer (a single consumer listening to multiple queues) is only supported for message-driven conssumers; polled consumers can only retrieve messages from a single queue.
+
 == Configuration Options
 
 This section contains settings specific to the RabbitMQ Binder and bound channels.

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestBinder.java
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.util.StringUtils;
 
 /**
  * Test support class for {@link RabbitMessageChannelBinder}.
@@ -92,15 +93,31 @@ public class RabbitTestBinder extends
 
 	private void captureConsumerResources(String name, String group,
 			ExtendedConsumerProperties<RabbitConsumerProperties> properties) {
+		String[] names = null;
 		if (group != null) {
 			if (properties.getExtension().isQueueNameGroupOnly()) {
 				this.queues.add(properties.getExtension().getPrefix() + group);
 			}
 			else {
-				this.queues.add(properties.getExtension().getPrefix() + name + ("." + group));
+				if (properties.isMultiplex()) {
+					names = StringUtils.commaDelimitedListToStringArray(name);
+					for (String nayme : names) {
+						this.queues.add(properties.getExtension().getPrefix() + nayme.trim() + "." + group);
+					}
+				}
+				else {
+					this.queues.add(properties.getExtension().getPrefix() + name + "." + group);
+				}
 			}
 		}
-		this.exchanges.add(properties.getExtension().getPrefix() + name);
+		if (names != null) {
+			for (String nayme : names) {
+				this.exchanges.add(properties.getExtension().getPrefix() + nayme.trim());
+			}
+		}
+		else {
+			this.exchanges.add(properties.getExtension().getPrefix() + name);
+		}
 		this.prefixes.add(properties.getExtension().getPrefix());
 		deadLetters(properties.getExtension());
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/149

When a consumer is multiplexed, configure the container to listen to multiple queues.
Not currently supported for the polled consumer.

When using a DLQ, determine the routing key from the queue in the failed message (unless
an explicit DLQ name has been provisioned - in which case, the same DLQ will be used
for all queues.