### PR TITLE
GH-152: Inject nullChannel for confirm acks

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -285,6 +285,8 @@ public class RabbitMessageChannelBinder
 			checkConnectionFactoryIsErrorCapable();
 			endpoint.setReturnChannel(errorChannel);
 			endpoint.setConfirmNackChannel(errorChannel);
+			endpoint.setConfirmAckChannel(getApplicationContext().getBean(
+					IntegrationContextUtils.NULL_CHANNEL_BEAN_NAME, MessageChannel.class));
 			endpoint.setConfirmCorrelationExpressionString("#root");
 			endpoint.setErrorMessageStrategy(new DefaultErrorMessageStrategy());
 		}


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/152

Reduce log noise since we only express interest in nacks.

**cherry-pick to 2.0.x**