### PR TITLE
GH-156: Fix outbound contentType

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -171,8 +171,14 @@ public class RabbitBinderTests extends
 		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
 		Binding<MessageChannel> producerBinding = binder.bindProducer("bad.0", moduleOutputChannel,
 				createProducerProperties());
+		assertThat(TestUtils.getPropertyValue(producerBinding, "lifecycle.headersMappedLast", Boolean.class))
+			.isTrue();
+		assertThat(TestUtils.getPropertyValue(producerBinding, "lifecycle.amqpTemplate.messageConverter")
+				.getClass().getName()).contains("Passthrough");
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer("bad.0", "test", moduleInputChannel,
 				createConsumerProperties());
+		assertThat(TestUtils.getPropertyValue(consumerBinding, "lifecycle.messageConverter")
+				.getClass().getName()).contains("Passthrough");
 		Message<?> message = MessageBuilder.withPayload("bad".getBytes()).setHeader(MessageHeaders.CONTENT_TYPE, "foo/bar").build();
 		final CountDownLatch latch = new CountDownLatch(3);
 		moduleInputChannel.subscribe(new MessageHandler() {


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/156

The `SimpleMessageConverter` overwrote the `contentType` property with `application/octet-stream`.

`contentType` set by the stream converter should win.

- `setHeadersMappedLast(true)`
- replace the converter with a simple `byte[]` pass-through converter on both sides.
- if (for some reason) the stream converter produces something other than `byte[]` fall back to
the `SimpleMessageConverter`.
- remove the `afterPropertiesSet` since it's done by the abstract binder.

**cherry-pick to 2.0.x**