### PR TITLE
GH-162 [DO NOT MERGE] made SPEL properties consistent

### DIFF
--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.stream.binder.rabbit.properties;
 import javax.validation.constraints.Min;
 
 import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.expression.Expression;
 
 /**
  * @author Marius Bogoevici
@@ -69,12 +70,12 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 	/**
 	 * when using a delayed message exchange, a SpEL expression to determine the delay to apply to messages
 	 */
-	private String delayExpression;
+	private Expression delayExpression;
 
 	/**
 	 * a custom routing key when publishing messages; default is the destination name; suffixed by "-partition" when partitioned
 	 */
-	private String routingKeyExpression;
+	private Expression routingKeyExpression;
 
 	/**
 	 * @deprecated - use {@link #setHeaderPatterns(String[])}.
@@ -161,19 +162,19 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 		this.transacted = transacted;
 	}
 
-	public String getDelayExpression() {
+	public Expression getDelayExpression() {
 		return this.delayExpression;
 	}
 
-	public void setDelayExpression(String delayExpression) {
+	public void setDelayExpression(Expression delayExpression) {
 		this.delayExpression = delayExpression;
 	}
 
-	public String getRoutingKeyExpression() {
+	public Expression getRoutingKeyExpression() {
 		return this.routingKeyExpression;
 	}
 
-	public void setRoutingKeyExpression(String routingKeyExpression) {
+	public void setRoutingKeyExpression(Expression routingKeyExpression) {
 		this.routingKeyExpression = routingKeyExpression;
 	}
 

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitExpressionEvaluatingInterceptor.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitExpressionEvaluatingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,17 +23,18 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.util.Assert;
 
 /**
  * Interceptor to evaluate expressions for outbound messages before serialization.
  *
  * @author Gary Russell
+ * @author Oleg Zhurakousky
  * @since 2.0
  *
  */
-public class RabbitExpressionEvaluatingInterceptor extends ChannelInterceptorAdapter {
+public class RabbitExpressionEvaluatingInterceptor implements ChannelInterceptor {
 
 	public static final ExpressionParser PARSER = new SpelExpressionParser();
 
@@ -54,19 +55,19 @@ public class RabbitExpressionEvaluatingInterceptor extends ChannelInterceptorAda
 	 * @param delayExpression the delay expression.
 	 * @param evaluationContext the evaluation context.
 	 */
-	public RabbitExpressionEvaluatingInterceptor(String routingKeyExpression, String delayExpression,
+	public RabbitExpressionEvaluatingInterceptor(Expression routingKeyExpression, Expression delayExpression,
 			EvaluationContext evaluationContext) {
 		Assert.isTrue(routingKeyExpression != null || delayExpression != null,
 				"At least one expression is required");
 		Assert.notNull(evaluationContext, "the 'evaluationContext' cannot be null");
 		if (routingKeyExpression != null) {
-			this.routingKeyExpression = PARSER.parseExpression(routingKeyExpression);
+			this.routingKeyExpression = routingKeyExpression;
 		}
 		else {
 			this.routingKeyExpression = null;
 		}
 		if (delayExpression != null) {
-			this.delayExpression = PARSER.parseExpression(delayExpression);
+			this.delayExpression = delayExpression;
 		}
 		else {
 			this.delayExpression = null;

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -151,7 +151,7 @@ public class RabbitBinderTests extends
 		ExtendedProducerProperties<RabbitProducerProperties> props = new ExtendedProducerProperties<>(
 				new RabbitProducerProperties());
 		if (testName.getMethodName().equals("testPartitionedModuleSpEL")) {
-			props.getExtension().setRoutingKeyExpression("'part.0'");
+			props.getExtension().setRoutingKeyExpression(spelExpressionParser.parseExpression("'part.0'"));
 		}
 		return props;
 	}
@@ -529,7 +529,7 @@ public class RabbitBinderTests extends
 		producerProperties.setPartitionSelectorClass(TestPartitionSelectorClass.class);
 		producerProperties.setPartitionCount(1);
 		producerProperties.getExtension().setTransacted(true);
-		producerProperties.getExtension().setDelayExpression("42");
+		producerProperties.getExtension().setDelayExpression(spelExpressionParser.parseExpression("42"));
 		producerProperties.setRequiredGroups("prodPropsRequired");
 
 		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
@@ -1290,7 +1290,7 @@ public class RabbitBinderTests extends
 	public void testRoutingKeyExpression() throws Exception {
 		RabbitTestBinder binder = getBinder();
 		ExtendedProducerProperties<RabbitProducerProperties> producerProperties = createProducerProperties();
-		producerProperties.getExtension().setRoutingKeyExpression("payload.field");
+		producerProperties.getExtension().setRoutingKeyExpression(spelExpressionParser.parseExpression("payload.field"));
 
 		DirectChannel output = createBindableChannel("output", createProducerBindingProperties(producerProperties));
 		output.setBeanName("rkeProducer");
@@ -1327,10 +1327,10 @@ public class RabbitBinderTests extends
 	public void testRoutingKeyExpressionPartitionedAndDelay() throws Exception {
 		RabbitTestBinder binder = getBinder();
 		ExtendedProducerProperties<RabbitProducerProperties> producerProperties = createProducerProperties();
-		producerProperties.getExtension().setRoutingKeyExpression("payload.field");
+		producerProperties.getExtension().setRoutingKeyExpression(spelExpressionParser.parseExpression("payload.field"));
 		// requires delayed message exchange plugin; tested locally
 //		producerProperties.getExtension().setDelayedExchange(true);
-		producerProperties.getExtension().setDelayExpression("1000");
+		producerProperties.getExtension().setDelayExpression(spelExpressionParser.parseExpression("1000"));
 		producerProperties.setPartitionKeyExpression(new ValueExpression<>(0));
 
 		DirectChannel output = createBindableChannel("output", createProducerBindingProperties(producerProperties));


### PR DESCRIPTION
Initial change in RabbitProducerProperties to use Expression as type of SPEL properties rather then String

Resolves spring-cloud/spring-cloud-stream-binder-rabbit#162