### PR TITLE
Extended default properties

### DIFF
--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitCommonProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitCommonProperties.java
@@ -19,13 +19,15 @@ package org.springframework.cloud.stream.binder.rabbit.properties;
 import org.hibernate.validator.constraints.Range;
 
 import org.springframework.amqp.core.ExchangeTypes;
+import org.springframework.cloud.stream.config.MergableProperties;
 
 /**
  * @author Gary Russell
+ * @author Soby Chacko
  * @since 1.2
  *
  */
-public abstract class RabbitCommonProperties {
+public abstract class RabbitCommonProperties implements MergableProperties {
 
 	public static final String DEAD_LETTER_EXCHANGE = "DLX";
 

--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitExtendedBindingProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitExtendedBindingProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,12 @@ import org.springframework.cloud.stream.binder.ExtendedBindingProperties;
  * @author Marius Bogoevici
  * @author Gary Russell
  * @author Oleg Zhurakousky
+ * @author Soby Chacko
  */
 @ConfigurationProperties("spring.cloud.stream.rabbit")
 public class RabbitExtendedBindingProperties implements ExtendedBindingProperties<RabbitConsumerProperties, RabbitProducerProperties> {
+
+	private static final String DEFAULTS_PREFIX = "spring.cloud.stream.rabbit.default";
 
 	private Map<String, RabbitBindingProperties> bindings = new HashMap<>();
 
@@ -80,6 +83,16 @@ public class RabbitExtendedBindingProperties implements ExtendedBindingPropertie
 			bindings.put(channelName, rbp);
 		}
 		return properties;
+	}
+
+	@Override
+	public String getDefaultsPrefix() {
+		return DEFAULTS_PREFIX;
+	}
+
+	@Override
+	public Class<?> getExtendedPropertiesEntryClass() {
+		return RabbitBindingProperties.class;
 	}
 
 }

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -106,6 +106,7 @@ import com.rabbitmq.client.Envelope;
  * @author David Turanski
  * @author Marius Bogoevici
  * @author Artem Bilan
+ * @author Soby Chacko
  */
 public class RabbitMessageChannelBinder
 		extends AbstractMessageChannelBinder<ExtendedConsumerProperties<RabbitConsumerProperties>,
@@ -234,6 +235,16 @@ public class RabbitMessageChannelBinder
 	@Override
 	public RabbitProducerProperties getExtendedProducerProperties(String channelName) {
 		return this.extendedBindingProperties.getExtendedProducerProperties(channelName);
+	}
+
+	@Override
+	public String getDefaultsPrefix() {
+		return this.extendedBindingProperties.getDefaultsPrefix();
+	}
+
+	@Override
+	public Class<?> getExtendedPropertiesEntryClass() {
+		return this.extendedBindingProperties.getExtendedPropertiesEntryClass();
 	}
 
 	@Override


### PR DESCRIPTION
Allow applications to configure default values for extended prducer and
consumer properties across multiple bindings in order to avoid repetition.

Requires https://github.com/spring-cloud/spring-cloud-stream/pull/1477