### PR TITLE
GH-176: Add DLX Provisioning Flexibility

### DIFF
--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitCommonProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitCommonProperties.java
@@ -105,6 +105,16 @@ public abstract class RabbitCommonProperties {
 	private String deadLetterExchange;
 
 	/**
+	 * the type of the DLX, if autoBindDlq is true
+	 */
+	private String deadLetterExchangeType = ExchangeTypes.DIRECT;
+
+	/**
+	 * whether to declare the dead-letter exchange when autoBindDlq is true.
+	 */
+	private boolean declareDlx = true;
+
+	/**
 	 * a dead letter routing key to assign to that queue; if autoBindDlq is true, defaults to destination
 	 */
 	private String deadLetterRoutingKey;
@@ -293,6 +303,22 @@ public abstract class RabbitCommonProperties {
 
 	public void setDeadLetterExchange(String deadLetterExchange) {
 		this.deadLetterExchange = deadLetterExchange;
+	}
+
+	public String getDeadLetterExchangeType() {
+		return this.deadLetterExchangeType;
+	}
+
+	public void setDeadLetterExchangeType(String deadLetterExchangeType) {
+		this.deadLetterExchangeType = deadLetterExchangeType;
+	}
+
+	public boolean isDeclareDlx() {
+		return this.declareDlx;
+	}
+
+	public void setDeclareDlx(boolean declareDlx) {
+		this.declareDlx = declareDlx;
 	}
 
 	public String getDeadLetterRoutingKey() {

--- a/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/overview.adoc
@@ -144,11 +144,22 @@ A DLX to assign to the queue.
 Relevant only if `autoBindDlq` is `true`.
 +
 Default: 'prefix+DLX'
+deadLetterExchangeType::
+The type of the DLX to assign to the queue.
+Relevant only if `autoBindDlq` is `true`.
++
+Default: 'direct'
 deadLetterRoutingKey::
 A dead letter routing key to assign to the queue.
 Relevant only if `autoBindDlq` is `true`.
 +
 Default: `destination`
+declareDlx::
+Whether to declare the dead letter exchange for the destination.
+Relevant only if `autoBindDlq` is `true`.
+Set to `false` if you have a pre-configured DLX.
++
+Default: `true`.
 declareExchange::
 Whether to declare the exchange for the destination.
 +
@@ -376,12 +387,25 @@ Relevant only when `autoBindDlq` is `true`.
 Applies only when `requiredGroups` are provided and then only to those groups.
 +
 Default: 'prefix+DLX'
+deadLetterExchangeType::
+The type of the DLX to assign to the queue.
+Relevant only if `autoBindDlq` is `true`.
+Applies only when `requiredGroups` are provided and then only to those groups.
++
+Default: 'direct'
 deadLetterRoutingKey::
 A dead letter routing key to assign to the queue.
 Relevant only when `autoBindDlq` is `true`.
 Applies only when `requiredGroups` are provided and then only to those groups.
 +
 Default: `destination`
+declareDlx::
+Whether to declare the dead letter exchange for the destination.
+Relevant only if `autoBindDlq` is `true`.
+Set to `false` if you have a pre-configured DLX.
+Applies only when `requiredGroups` are provided and then only to those groups.
++
+Default: `true`.
 declareExchange::
 Whether to declare the exchange for the destination.
 +

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -422,6 +422,7 @@ public class RabbitBinderTests extends
 		extProps.setAutoBindDlq(true);
 		extProps.setDeadLetterQueueName("customDLQ");
 		extProps.setDeadLetterExchange("customDLX");
+		extProps.setDeadLetterExchangeType(ExchangeTypes.TOPIC);
 		extProps.setDeadLetterRoutingKey("customDLRK");
 		extProps.setDlqDeadLetterExchange("propsUser3");
 		extProps.setDlqDeadLetterRoutingKey("propsUser3");
@@ -462,6 +463,16 @@ public class RabbitBinderTests extends
 		assertThat(exchange).isInstanceOf(DirectExchange.class);
 		assertThat(exchange.isDurable()).isEqualTo(false);
 		assertThat(exchange.isAutoDelete()).isEqualTo(true);
+
+		exchange = rmt.getExchange("customDLX");
+		n = 0;
+		while (n++ < 100 && exchange == null) {
+			Thread.sleep(100);
+			exchange = rmt.getExchange("customDLX");
+		}
+		assertThat(exchange).isInstanceOf(TopicExchange.class);
+		assertThat(exchange.isDurable()).isEqualTo(true);
+		assertThat(exchange.isAutoDelete()).isEqualTo(false);
 
 		QueueInfo queue = rmt.getClient().getQueue("/", "propsUser3.infra");
 		n = 0;


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/176

- Add `declareDlx` to suppress declaration of DLX
- Add `deadLetterExchangeType` to allow specification of the type