### PR TITLE
GH-189 Support binding anon to built-in exchange

### DIFF
--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisioner.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisioner.java
@@ -24,7 +24,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.amqp.AmqpConnectException;
-import org.springframework.amqp.core.AnonymousQueue;
+import org.springframework.amqp.core.Base64UrlNamingStrategy;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Binding.DestinationType;
 import org.springframework.amqp.core.BindingBuilder;
@@ -64,8 +64,8 @@ public class RabbitExchangeQueueProvisioner implements ApplicationListener<Decla
 		ProvisioningProvider<ExtendedConsumerProperties<RabbitConsumerProperties>,
 							ExtendedProducerProperties<RabbitProducerProperties>> {
 
-	private static final AnonymousQueue.Base64UrlNamingStrategy ANONYMOUS_GROUP_NAME_GENERATOR
-			= new AnonymousQueue.Base64UrlNamingStrategy("anonymous.");
+	private static final Base64UrlNamingStrategy ANONYMOUS_GROUP_NAME_GENERATOR
+			= new Base64UrlNamingStrategy("anonymous.");
 
 	/**
 	 * The delimiter between a group and index when constructing a binder
@@ -148,8 +148,11 @@ public class RabbitExchangeQueueProvisioner implements ApplicationListener<Decla
 	private ConsumerDestination doProvisionConsumerDestination(String name, String group,
 			ExtendedConsumerProperties<RabbitConsumerProperties> properties) {
 		boolean anonymous = !StringUtils.hasText(group);
-		String  baseQueueName = anonymous ? groupedName(name, ANONYMOUS_GROUP_NAME_GENERATOR.generateName())
-					: properties.getExtension().isQueueNameGroupOnly() ? group : groupedName(name, group);
+		String  baseQueueName = properties.getExtension().isQueueNameGroupOnly()
+				? anonymous ? ANONYMOUS_GROUP_NAME_GENERATOR.generateName()
+							: group
+				: anonymous ? groupedName(name, ANONYMOUS_GROUP_NAME_GENERATOR.generateName())
+							: groupedName(name, group);
 		if (this.logger.isInfoEnabled()) {
 			this.logger.info("declaring queue for inbound: " + baseQueueName + ", bound to: " + name);
 		}

--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisioner.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisioner.java
@@ -148,11 +148,13 @@ public class RabbitExchangeQueueProvisioner implements ApplicationListener<Decla
 	private ConsumerDestination doProvisionConsumerDestination(String name, String group,
 			ExtendedConsumerProperties<RabbitConsumerProperties> properties) {
 		boolean anonymous = !StringUtils.hasText(group);
-		String  baseQueueName = properties.getExtension().isQueueNameGroupOnly()
-				? anonymous ? ANONYMOUS_GROUP_NAME_GENERATOR.generateName()
-							: group
-				: anonymous ? groupedName(name, ANONYMOUS_GROUP_NAME_GENERATOR.generateName())
-							: groupedName(name, group);
+		String  baseQueueName;
+		if (properties.getExtension().isQueueNameGroupOnly()) {
+				baseQueueName =  anonymous ? ANONYMOUS_GROUP_NAME_GENERATOR.generateName() : group;
+		}
+		else {
+				baseQueueName = groupedName(name, anonymous ? ANONYMOUS_GROUP_NAME_GENERATOR.generateName() : group);
+		}
 		if (this.logger.isInfoEnabled()) {
 			this.logger.info("declaring queue for inbound: " + baseQueueName + ", bound to: " + name);
 		}

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -392,6 +392,25 @@ public class RabbitBinderTests extends
 	}
 
 	@Test
+	public void testAnonWithBuiltInExchange() throws Exception {
+		RabbitTestBinder binder = getBinder();
+		ExtendedConsumerProperties<RabbitConsumerProperties> properties = createConsumerProperties();
+		properties.getExtension().setDeclareExchange(false);
+		properties.getExtension().setQueueNameGroupOnly(true);
+
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer("amq.topic", null,
+				createBindableChannel("input", new BindingProperties()), properties);
+		Lifecycle endpoint = extractEndpoint(consumerBinding);
+		SimpleMessageListenerContainer container = TestUtils.getPropertyValue(endpoint, "messageListenerContainer",
+				SimpleMessageListenerContainer.class);
+		String queueName = container.getQueueNames()[0];
+		assertThat(queueName).startsWith("anonymous.");
+		assertThat(container.isRunning()).isTrue();
+		consumerBinding.unbind();
+		assertThat(container.isRunning()).isFalse();
+	}
+
+	@Test
 	public void testConsumerPropertiesWithUserInfrastructureCustomExchangeAndRK() throws Exception {
 		RabbitTestBinder binder = getBinder();
 		ExtendedConsumerProperties<RabbitConsumerProperties> properties = createConsumerProperties();


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/189

`queueNameGroupOnly` does not work with anonymous groups.