### PR TITLE
Fix documentation link to Error Handling in Spring Cloud Stream Binder

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -637,7 +637,7 @@ Notice that the count property in the `x-death` header is a `Long`.
 == Error Channels
 
 Starting with version 1.3, the binder unconditionally sends exceptions to an error channel for each consumer destination and can also be configured to send async producer send failures to an error channel.
-See "`<<binder-error-channels>>`" for more information.
+See "`<<spring-cloud-stream-overview-error-handling>>`" for more information.
 
 RabbitMQ has two types of send failures:
 
@@ -647,7 +647,7 @@ RabbitMQ has two types of send failures:
 The latter is rare.
 According to the RabbitMQ documentation "[A nack] will only be delivered if an internal error occurs in the Erlang process responsible for a queue.".
 
-As well as enabling producer error channels (as described in "`<<binder-error-channels>>`"), the RabbitMQ binder only sends messages to the channels if the connection factory is appropriately configured, as follows:
+As well as enabling producer error channels (as described in "`<<spring-cloud-stream-overview-error-handling>>`"), the RabbitMQ binder only sends messages to the channels if the connection factory is appropriately configured, as follows:
 
 * `ccf.setPublisherConfirms(true);`
 * `ccf.setPublisherReturns(true);`


### PR DESCRIPTION
I did not manage to build it locally in a way that links resolve to the main project docs, but common sense tells me it will work ;-)