### PR TITLE
GH-251: RKExpression interceptor improvements

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -1631,7 +1631,7 @@ public class RabbitBinderTests extends
 		RabbitTestBinder binder = getBinder();
 		ExtendedProducerProperties<RabbitProducerProperties> producerProperties = createProducerProperties();
 		producerProperties.getExtension().setRoutingKeyExpression(
-				spelExpressionParser.parseExpression("payload.field"));
+				spelExpressionParser.parseExpression("#root.getPayload().field"));
 		// requires delayed message exchange plugin; tested locally
 		// producerProperties.getExtension().setDelayedExchange(true);
 		producerProperties.getExtension()


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/251

We apply the interceptor only if the expression contains `payload` but the interceptor
is needed if the expression refers to the complete `Message` (`#root` or `#this`).