### PR TITLE
GH-259: Fix DLQ binding with custom routing key

### DIFF
--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisioner.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisioner.java
@@ -356,7 +356,7 @@ public class RabbitExchangeQueueProvisioner
 			}
 			Map<String, Object> arguments = new HashMap<>(properties.getDlqBindingArguments());
 			Binding dlqBinding = new Binding(dlq.getName(), DestinationType.QUEUE,
-					dlxName, properties.getDlqDeadLetterRoutingKey() == null ? routingKey
+					dlxName, properties.getDeadLetterRoutingKey() == null ? routingKey
 							: properties.getDeadLetterRoutingKey(),
 					arguments);
 			declareBinding(dlqName, dlqBinding);


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/259

Previously, a custom dead letter routing key would only be used in the binding
if the dead letter queue itself also had a dead letter routing key.

The wrong property was being tested for non-null while creating the binding.

**cherry-pick to 2.2.x, 2.1.x**

Broken on 2.1.x by 75ebb08479de1fcfe514c557e35abfcac3acd5f6