### PR TITLE
GH-252: Support Consumer Batch Mode

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -377,6 +377,13 @@ To set listener container properties that are not exposed as binder or binding p
 The binder and binding properties will be set and then the customizer will be called.
 The customizer (`configure()` method) is provided with the queue name as well as the consumer group as arguments.
 
+[[rabbit-receiving-batch]]
+=== Receiving Batched Messages
+
+Normally, if a producer binding has `batch-enabled=true` (see <<rabbit-prod-props>>), or a message is created by a `BatchingRabbitTemplate`, elements of the batch are returned as individual calls to the listener method.
+Starting with version 3.0, any such batch can be presented as a `List<?>` to the listener method if `spring.cloud.stream.binding.<name>.consumer.batch-mode` is set to `true`.
+
+[[rabbit-prod-props]]
 === Rabbit Producer Properties
 
 The following properties are available for Rabbit producers only and must be prefixed with `spring.cloud.stream.rabbit.bindings.<channelName>.producer.`.
@@ -396,6 +403,7 @@ batchingEnabled::
 Whether to enable message batching by producers.
 Messages are batched into one message according to the following properties (described in the next three entries in this list): 'batchSize', `batchBufferLimit`, and `batchTimeout`.
 See https://docs.spring.io/spring-amqp//reference/html/_reference.html#template-batching[Batching] for more information.
+Also see <<rabbit-receiving-batch>>.
 +
 Default: `false`.
 batchSize::

--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitConsumerProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitConsumerProperties.java
@@ -52,7 +52,7 @@ public class RabbitConsumerProperties extends RabbitCommonProperties {
 	/**
 	 * messages per acknowledgment (and commit when transacted).
 	 */
-	private int txSize = 1;
+	private int batchSize = 1;
 
 	/**
 	 * true for a durable subscription.
@@ -178,13 +178,31 @@ public class RabbitConsumerProperties extends RabbitCommonProperties {
 		this.headerPatterns = requestHeaderPatterns;
 	}
 
+	/**
+	 * @deprecated in favor of {@link #getBatchSize()}
+	 * @return the tx size.
+	 */
+	@Deprecated
 	@Min(value = 1, message = "Tx Size should be greater than zero.")
 	public int getTxSize() {
-		return txSize;
+		return getBatchSize();
 	}
 
+	/**
+	 * deprecated in favor of {@link #setBatchSize(int)}.
+	 * @param txSize the tx size
+	 */
 	public void setTxSize(int txSize) {
-		this.txSize = txSize;
+		setBatchSize(txSize);
+	}
+
+	@Min(value = 1, message = "Batch Size should be greater than zero.")
+	public int getBatchSize() {
+		return batchSize;
+	}
+
+	public void setBatchSize(int batchSize) {
+		this.batchSize = batchSize;
 	}
 
 	public boolean isDurableSubscription() {

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -525,7 +525,8 @@ public class RabbitMessageChannelBinder extends
 		if (maxConcurrency > concurrency) {
 			listenerContainer.setMaxConcurrentConsumers(maxConcurrency);
 		}
-		listenerContainer.setTxSize(properties.getExtension().getTxSize());
+		listenerContainer.setDeBatchingEnabled(!properties.isBatchMode());
+		listenerContainer.setBatchSize(properties.getExtension().getBatchSize());
 		if (properties.getExtension().getQueueDeclarationRetries() != null) {
 			listenerContainer.setDeclarationRetries(
 					properties.getExtension().getQueueDeclarationRetries());
@@ -539,14 +540,14 @@ public class RabbitMessageChannelBinder extends
 		listenerContainer.setConsumersPerQueue(concurrency);
 		if (properties.getExtension().getMaxConcurrency() > concurrency) {
 			this.logger
-					.warn("maxConcurrency is not supported with a direct container type");
+					.warn("maxConcurrency is not supported by the direct container type");
 		}
-		if (properties.getExtension().getTxSize() > 1) {
-			this.logger.warn("txSize is not supported with a direct container type");
+		if (properties.getExtension().getBatchSize() > 1) {
+			this.logger.warn("batchSize is not supported by the direct container type");
 		}
 		if (properties.getExtension().getQueueDeclarationRetries() != null) {
 			this.logger.warn(
-					"queueDeclarationRetries is not supported with a direct container type");
+					"queueDeclarationRetries is not supported by the direct container type");
 		}
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/252

- also replace deprecated `txSize` with `batchSize` (unrelated to this feature).