### PR TITLE
GH-242: Support multiple queue bindings

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -139,9 +139,14 @@ Whether to automatically declare the DLQ and bind it to the binder DLX.
 Default: `false`.
 bindingRoutingKey::
 The routing key with which to bind the queue to the exchange (if `bindQueue` is `true`).
-For partitioned destinations, `-<instanceIndex>` is appended.
+Can be multiple keys - see `bindingRoutingKeyDelimiter`.
+For partitioned destinations, `-<instanceIndex>` is appended to each key.
 +
 Default: `#`.
+bindingRoutingKeyDelimiter::
+When this is not null, 'bindingRoutingKey' is considered to be a list of keys delimited by this value; often a comma is used.
++
+Default: `null`.
 bindQueue::
 Whether to declare the queue and bind it to the destination exchange.
 Set it to `false` if you have set up your own infrastructure and have previously created and bound the queue.
@@ -412,10 +417,16 @@ The batch timeout when batching is enabled.
 Default: `5000`.
 bindingRoutingKey::
 The routing key with which to bind the queue to the exchange (if `bindQueue` is `true`).
-Only applies to non-partitioned destinations.
+Can be multiple keys - see `bindingRoutingKeyDelimiter`.
+For partitioned destinations, `-n` is appended to each key.
 Only applies if `requiredGroups` are provided and then only to those groups.
 +
 Default: `#`.
+bindingRoutingKeyDelimiter::
+When this is not null, 'bindingRoutingKey' is considered to be a list of keys delimited by this value; often a comma is used.
+Only applies if `requiredGroups` are provided and then only to those groups.
++
+Default: `null`.
 bindQueue::
 Whether to declare the queue and bind it to the destination exchange.
 Set it to `false` if you have set up your own infrastructure and have previously created and bound the queue.

--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitCommonProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitCommonProperties.java
@@ -78,6 +78,11 @@ public abstract class RabbitCommonProperties {
 	private String bindingRoutingKey;
 
 	/**
+	 * when not null, treat 'bindingRoutingKey' as a delimited list of keys to bind.
+	 */
+	private String bindingRoutingKeyDelimiter;
+
+	/**
 	 * default time to live to apply to the queue when declared (ms).
 	 */
 	private Integer ttl;
@@ -268,6 +273,14 @@ public abstract class RabbitCommonProperties {
 
 	public void setBindingRoutingKey(String routingKey) {
 		this.bindingRoutingKey = routingKey;
+	}
+
+	public String getBindingRoutingKeyDelimiter() {
+		return this.bindingRoutingKeyDelimiter;
+	}
+
+	public void setBindingRoutingKeyDelimiter(String bindingRoutingKeyDelimiter) {
+		this.bindingRoutingKeyDelimiter = bindingRoutingKeyDelimiter;
 	}
 
 	public Integer getTtl() {

--- a/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -487,7 +487,8 @@ public class RabbitBinderTests extends
 		RabbitTestBinder binder = getBinder();
 		ExtendedConsumerProperties<RabbitConsumerProperties> properties = createConsumerProperties();
 		properties.getExtension().setExchangeType(ExchangeTypes.DIRECT);
-		properties.getExtension().setBindingRoutingKey("foo");
+		properties.getExtension().setBindingRoutingKey("foo,bar");
+		properties.getExtension().setBindingRoutingKeyDelimiter(",");
 		properties.getExtension().setQueueNameGroupOnly(true);
 		// properties.getExtension().setDelayedExchange(true); // requires delayed message
 		// exchange plugin; tested locally
@@ -509,10 +510,14 @@ public class RabbitBinderTests extends
 			Thread.sleep(100);
 			bindings = client.getBindingsBySource("/", "propsUser2");
 		}
-		assertThat(bindings.size()).isEqualTo(1);
+		assertThat(bindings.size()).isEqualTo(2);
 		assertThat(bindings.get(0).getSource()).isEqualTo("propsUser2");
 		assertThat(bindings.get(0).getDestination()).isEqualTo(group);
-		assertThat(bindings.get(0).getRoutingKey()).isEqualTo("foo");
+		assertThat(bindings.get(0).getRoutingKey()).isIn("foo", "bar");
+		assertThat(bindings.get(1).getSource()).isEqualTo("propsUser2");
+		assertThat(bindings.get(1).getDestination()).isEqualTo(group);
+		assertThat(bindings.get(1).getRoutingKey()).isIn("foo", "bar");
+		assertThat(bindings.get(1).getRoutingKey()).isNotEqualTo(bindings.get(0).getRoutingKey());
 
 		ExchangeInfo exchange = client.getExchange("/", "propsUser2");
 		while (n++ < 100 && exchange == null) {


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/242

Allow a consumer binding to bind its queue with multiple routing keys.

Add `bindingQueueDelimiter` to treat `bindingRoutingKey` as a list.