### PR TITLE
(documentation) Fix typo's in properties

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -410,7 +410,7 @@ The customizer (`configure()` method) is provided with the queue name as well as
 === Receiving Batched Messages
 
 Normally, if a producer binding has `batch-enabled=true` (see <<rabbit-prod-props>>), or a message is created by a `BatchingRabbitTemplate`, elements of the batch are returned as individual calls to the listener method.
-Starting with version 3.0, any such batch can be presented as a `List<?>` to the listener method if `spring.cloud.stream.binding.<name>.consumer.batch-mode` is set to `true`.
+Starting with version 3.0, any such batch can be presented as a `List<?>` to the listener method if `spring.cloud.stream.bindings.<name>.consumer.batch-mode` is set to `true`.
 
 [[rabbit-prod-props]]
 === Rabbit Producer Properties
@@ -692,8 +692,8 @@ There are a number of rabbit-specific binding properties that allow you to modif
 
 If you have an existing exchange/queue that you wish to use, you can completely disable automatic provisioning as follows, assuming the exchange is named `myExchange` and the queue is named `myQueue`:
 
-* `spring.cloud.stream.binding.<binding name>.destination=myExhange`
-* `spring.cloud.stream.binding.<binding name>.group=myQueue`
+* `spring.cloud.stream.bindings.<binding name>.destination=myExhange`
+* `spring.cloud.stream.bindings.<binding name>.group=myQueue`
 * `spring.cloud.stream.rabbit.bindings.<binding name>.consumer.bindQueue=false`
 * `spring.cloud.stream.rabbit.bindings.<binding name>.consumer.declareExchange=false`
 * `spring.cloud.stream.rabbit.bindings.<binding name>.consumer.queueNameGroupOnly=true`


### PR DESCRIPTION
The properties `spring.cloud.stream.binding.<binding name>` do not exist, and should be `spring.cloud.stream.bindings.<binding name>`