### PR TITLE
`republishToDlq` now default is `true`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -376,7 +376,7 @@ If a dead-letter queue (DLQ) is configured, RabbitMQ routes the failed message (
 If set to `true`, the binder republishs failed messages to the DLQ with additional headers, including the exception message and stack trace from the cause of the final failure.
 Also see the <<spring-cloud-stream-rabbit-frame-max-headroom, frameMaxHeadroom property>>.
 +
-Default: false
+Default: true
 transacted::
 Whether to use transacted channels.
 +


### PR DESCRIPTION
@pivotal-issuemaster This is an Obvious Fix
https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/blob/master/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitConsumerProperties.java#L65