### PR TITLE
GH-298: Documentation: republishToDlq is now true by default

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -410,7 +410,7 @@ If a dead-letter queue (DLQ) is configured, RabbitMQ routes the failed message (
 If set to `true`, the binder republishs failed messages to the DLQ with additional headers, including the exception message and stack trace from the cause of the final failure.
 Also see the <<spring-cloud-stream-rabbit-frame-max-headroom, frameMaxHeadroom property>>.
 +
-Default: false
+Default: `true`
 singleActiveConsumer::
 Set to true to set the `x-single-active-consumer` queue property to true.
 +

--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -389,7 +389,7 @@ If a dead-letter queue (DLQ) is configured, RabbitMQ routes the failed message (
 If set to `true`, the binder republishs failed messages to the DLQ with additional headers, including the exception message and stack trace from the cause of the final failure.
 Also see the <<spring-cloud-stream-rabbit-frame-max-headroom, frameMaxHeadroom property>>.
 +
-Default: false
+Default: `true`
 singleActiveConsumer::
 Set to true to set the `x-single-active-consumer` queue property to true.
 +


### PR DESCRIPTION
This is the case since c2ed214df76fc0398a65a35ffd84d1cf079b8f3b.

A documentation update has already been done by @kinjelom in #285 but only README.adoc was modified.
As the contents of README.adoc is generated, this correction was overridden by d05bdc378214327295c885d12a321e6e77b3d4fe.

This commit modifies the source file, overview.adoc, and includes the newly generated README.adoc file.

@pivotal-issuemaster This is an Obvious Fix