### PR TITLE
Remove TODO from binder config

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
@@ -123,7 +123,6 @@ public class RabbitMessageChannelBinderConfiguration {
 		final AtomicInteger nameIncrementer = new AtomicInteger();
 		ConnectionNameStrategy namer = f -> this.rabbitBinderConfigurationProperties
 				.getConnectionNamePrefix() + "#" + nameIncrementer.getAndIncrement();
-		// TODO: this can be removed when Boot 2.0.1 wires it in
 		cf.setConnectionNameStrategy(namer);
 		return namer;
 	}


### PR DESCRIPTION
Even though Boot auto-configures a `ConnectionNameStrategy` we cannot
remove it from the binder configuration because Boot auto-configuration
runs before the binder configuration.