### PR TITLE
GH-307: Fix circular bean reference

### DIFF
--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
@@ -21,16 +21,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.MessagePostProcessor;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.AbstractConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionNameStrategy;
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.amqp.support.postprocessor.DelegatingDecompressingPostProcessor;
 import org.springframework.amqp.support.postprocessor.GZipPostProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.amqp.RabbitProperties;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.rabbit.RabbitMessageChannelBinder;
@@ -65,7 +62,7 @@ import org.springframework.lang.Nullable;
 public class RabbitMessageChannelBinderConfiguration {
 
 	@Autowired
-	private ConnectionFactory rabbitConnectionFactory;
+	private AbstractConnectionFactory rabbitConnectionFactory;
 
 	@Autowired
 	private RabbitProperties rabbitProperties;
@@ -82,8 +79,15 @@ public class RabbitMessageChannelBinderConfiguration {
 			@Nullable MessageSourceCustomizer<AmqpMessageSource> sourceCustomizer,
 			@Nullable ProducerMessageHandlerCustomizer<AmqpOutboundEndpoint> producerMessageHandlerCustomizer,
 			@Nullable ConsumerEndpointCustomizer<AmqpInboundChannelAdapter> consumerCustomizer,
-			List<DeclarableCustomizer> declarableCustomizers) {
+			List<DeclarableCustomizer> declarableCustomizers,
+			@Nullable ConnectionNameStrategy connectionNameStrategy) {
 
+		String connectionNamePrefix = this.rabbitBinderConfigurationProperties.getConnectionNamePrefix();
+		if (connectionNamePrefix != null &&  connectionNameStrategy == null) {
+			final AtomicInteger nameIncrementer = new AtomicInteger();
+			this.rabbitConnectionFactory.setConnectionNameStrategy(f -> connectionNamePrefix
+					+ "#" + nameIncrementer.getAndIncrement());
+		}
 		RabbitMessageChannelBinder binder = new RabbitMessageChannelBinder(
 				this.rabbitConnectionFactory, this.rabbitProperties,
 				provisioningProvider(declarableCustomizers), listenerContainerCustomizer, sourceCustomizer);
@@ -114,18 +118,6 @@ public class RabbitMessageChannelBinderConfiguration {
 	@Bean
 	RabbitExchangeQueueProvisioner provisioningProvider(List<DeclarableCustomizer> customizers) {
 		return new RabbitExchangeQueueProvisioner(this.rabbitConnectionFactory, customizers);
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(ConnectionNameStrategy.class)
-	@ConditionalOnProperty("spring.cloud.stream.rabbit.binder.connection-name-prefix")
-	public ConnectionNameStrategy connectionNamer(CachingConnectionFactory cf) {
-		final AtomicInteger nameIncrementer = new AtomicInteger();
-		ConnectionNameStrategy namer = f -> this.rabbitBinderConfigurationProperties
-				.getConnectionNamePrefix() + "#" + nameIncrementer.getAndIncrement();
-		// TODO: this can be removed when Boot 2.0.1 wires it in
-		cf.setConnectionNameStrategy(namer);
-		return namer;
 	}
 
 }


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/307

Fix `ConnectionNameStrategy` circular bean reference.

While not intuitive, retain the existing behavior whereby the presence of
a `ConnectionNameStrategy` bean overides the property.