### PR TITLE
GH-313: Fix DLQ Transactions and Confirms/Returns

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -57,6 +57,11 @@ Starting with version 2.1, this is true regardless of the setting of `republishT
 IMPORTANT: Setting `requeueRejected` to `true` (with `republishToDlq=false` ) causes the message to be re-queued and redelivered continually, which is likely not what you want unless the reason for the failure is transient.
 In general, you should enable retry within the binder by setting `maxAttempts` to greater than one or by setting `republishToDlq` to `true`.
 
+Starting with version 3.1.2, if the consumer is marked as `transacted`, publishing to the DLQ will participate in the transaction.
+This allows the transaction to roll back if the publishing fails for some reason (for example, if the user is not authorized to publish to the dead letter exchange).
+In addition, if the connection factory is configured for publisher confirms or returns, the publication to the DLQ will wait for the confirmation and check for a returned message.
+If a negative acknowledgment or returned message is received, the binder will throw an `AmqpRejectAndDontRequeueException`, allowing the broker to take care of publishing to the DLQ as if the `republishToDlq` property is `false`.
+
 See <<rabbit-binder-properties>> for more information about these properties.
 
 The framework does not provide any standard mechanism to consume dead-letter messages (or to re-route them back to the primary queue).


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/313

- Detect a transactional consumer and publish to the DLQ in the same transaction.
- Detect confirms/returns config and wait for confirm if so configured.
- Add tests for transactional publication, both types of confirms.
- Returned message and negative ack tested manually.