### PR TITLE
GH-317 Adding static routing key field to producer properties

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -889,9 +889,13 @@ Applies only when `requiredGroups` are provided and then only to those groups.
 Default: none - broker default will apply.
 routingKeyExpression::
 A SpEL expression to determine the routing key to use when publishing messages.
-For a fixed routing key, use a literal expression, such as `routingKeyExpression='my.routingKey'` in a properties file or `routingKeyExpression: '''my.routingKey'''` in a YAML file.
+For a fixed routing key, use `routingKey``.
 +
 Default: `destination` or `destination-<partition>` for partitioned destinations.
+routingKey::
+A string defining a fixed routing key to use when publishing messages.
++
+Default: see `routingKeyExpression`
 singleActiveConsumer::
 Set to true to set the `x-single-active-consumer` queue property to true.
 Applies only when `requiredGroups` are provided and then only to those groups.

--- a/README.adoc
+++ b/README.adoc
@@ -889,7 +889,7 @@ Applies only when `requiredGroups` are provided and then only to those groups.
 Default: none - broker default will apply.
 routingKeyExpression::
 A SpEL expression to determine the routing key to use when publishing messages.
-For a fixed routing key, use `routingKey``.
+For a fixed routing key, use `routingKey`.
 +
 Default: `destination` or `destination-<partition>` for partitioned destinations.
 routingKey::

--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -928,9 +928,13 @@ Applies only when `requiredGroups` are provided and then only to those groups.
 Default: none - broker default will apply.
 routingKeyExpression::
 A SpEL expression to determine the routing key to use when publishing messages.
-For a fixed routing key, use a literal expression, such as `routingKeyExpression='my.routingKey'` in a properties file or `routingKeyExpression: '''my.routingKey'''` in a YAML file.
+For a fixed routing key, use `routingKey``.
 +
 Default: `destination` or `destination-<partition>` for partitioned destinations.
+routingKey::
+A string defining a fixed routing key to use when publishing messages.
++
+Default: see `routingKeyExpression`
 singleActiveConsumer::
 Set to true to set the `x-single-active-consumer` queue property to true.
 Applies only when `requiredGroups` are provided and then only to those groups.

--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -928,7 +928,7 @@ Applies only when `requiredGroups` are provided and then only to those groups.
 Default: none - broker default will apply.
 routingKeyExpression::
 A SpEL expression to determine the routing key to use when publishing messages.
-For a fixed routing key, use `routingKey``.
+For a fixed routing key, use `routingKey`.
 +
 Default: `destination` or `destination-<partition>` for partitioned destinations.
 routingKey::

--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.rabbit.properties;
 
+import java.util.Optional;
+
 import jakarta.validation.constraints.Min;
 
 import org.springframework.amqp.core.MessageDeliveryMode;
@@ -23,8 +25,6 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.util.Assert;
 
-import javax.validation.constraints.Min;
-import java.util.Optional;
 
 
 /**

--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.Min;
 
 import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.expression.Expression;
+import org.springframework.expression.common.LiteralExpression;
 import org.springframework.util.Assert;
 
 /**
@@ -237,6 +238,10 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 
 	public void setRoutingKeyExpression(Expression routingKeyExpression) {
 		this.routingKeyExpression = routingKeyExpression;
+	}
+
+	public void setRoutingKey(String routingKey) {
+		setRoutingKeyExpression(new LiteralExpression(routingKey));
 	}
 
 	public String getConfirmAckChannel() {

--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
@@ -23,6 +23,10 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.util.Assert;
 
+import javax.validation.constraints.Min;
+import java.util.Optional;
+
+
 /**
  * @author Marius Bogoevici
  * @author Gary Russell
@@ -102,6 +106,12 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 	 * apply to messages.
 	 */
 	private Expression delayExpression;
+
+	/**
+	 * a static routing key when publishing messages; default is the destination name;
+	 * suffixed by "-partition" when partitioned. This is only used if `routingKeyExpression` is null
+	 */
+	private String routingKey;
 
 	/**
 	 * a custom routing key when publishing messages; default is the destination name;
@@ -232,16 +242,23 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 		this.delayExpression = delayExpression;
 	}
 
-	public Expression getRoutingKeyExpression() {
-		return this.routingKeyExpression;
-	}
+    public Expression getRoutingKeyExpression() {
+        return Optional.ofNullable(this.routingKeyExpression)
+                .orElseGet(() -> Optional.ofNullable(this.routingKey)
+                        .map(LiteralExpression::new)
+                        .orElse(null));
+    }
 
 	public void setRoutingKeyExpression(Expression routingKeyExpression) {
 		this.routingKeyExpression = routingKeyExpression;
 	}
 
+	public String getRoutingKey() {
+		return this.routingKey;
+	}
+
 	public void setRoutingKey(String routingKey) {
-		setRoutingKeyExpression(new LiteralExpression(routingKey));
+		this.routingKey = routingKey;
 	}
 
 	public String getConfirmAckChannel() {

--- a/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
+++ b/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
@@ -242,12 +242,12 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 		this.delayExpression = delayExpression;
 	}
 
-    public Expression getRoutingKeyExpression() {
-        return Optional.ofNullable(this.routingKeyExpression)
-                .orElseGet(() -> Optional.ofNullable(this.routingKey)
-                        .map(LiteralExpression::new)
-                        .orElse(null));
-    }
+	public Expression getRoutingKeyExpression() {
+		return Optional.ofNullable(this.routingKeyExpression)
+				.orElseGet(() -> Optional.ofNullable(this.routingKey)
+						.map(LiteralExpression::new)
+						.orElse(null));
+	}
 
 	public void setRoutingKeyExpression(Expression routingKeyExpression) {
 		this.routingKeyExpression = routingKeyExpression;


### PR DESCRIPTION
There seems to be several people running into issues where `SpelConverter` (found in `org.springframework.cloud.stream.config.SpelExpressionConverterConfiguration`) is missing from the `ApplicationConversionService` during configuration binding. 

While the root issue likely lies in application mis-configuration, it is a bit frustrating to debug this to simply set a static routing key. By providing an easier way for users to define a static routing key, this works around the issue. #317 