### PR TITLE
Addressing Rabbit Binder Health Indicator Issues

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -1209,3 +1209,22 @@ For negatively acknowledged confirmations, the payload is a `NackedAmqpMessageEx
 
 There is no automatic handling of these exceptions (such as sending to a <<rabbit-dlq-processing, dead-letter queue>>).
 You can consume these exceptions with your own Spring Integration flow.
+
+[[rabbit-binder-health-indicator]]
+== Rabbit Binder Health Indicator
+
+The health indicator for Rabbit binder delegates to the one provided from Spring Boot.
+For more information on this, see https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#actuator.endpoints.health.auto-configured-health-indicators[this].
+
+You can disable this health indicator at the binder level by using the property - `management.health.binders.enabled` and set this to `false`.
+In the case of multibinder environements, this has to be set on the binder's environment properties.
+
+When the health indicator is disabled, you should see something like the below in the health actuator endpoint:
+
+```
+"rabbit": {
+  "status": "UNKNOWN"
+}
+```
+
+At the Spring Boot level, if you want to disable the Rabbit health indicator, you need to use the property `management.health.rabbit.enabled` and set to `false`.

--- a/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitBinderConfiguration.java
+++ b/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitBinderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.amqp.RabbitHealthIndicator;
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.amqp.RabbitProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -54,6 +55,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Chris Bono
+ * @author Soby Chacko
  */
 @Configuration
 @ConditionalOnMissingBean(Binder.class)
@@ -205,6 +207,7 @@ public abstract class RabbitBinderConfiguration {
 	 */
 	@Configuration
 	@ConditionalOnClass(name = "org.springframework.boot.actuate.health.HealthIndicator")
+	@ConditionalOnEnabledHealthIndicator("binders")
 	public static class RabbitHealthIndicatorConfiguration {
 
 		@Bean


### PR DESCRIPTION
Currently, using the property management.health.binders.enabled,
we cannot disable the Rabbit health indicator. Addressing this issue.

Adding docs.

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/341